### PR TITLE
feat: 인증번호 저장 / 인증번호로 이메일 인증 구현

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,6 +9,13 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    # Github Actions 환경에서 레디스 연결
+    services:
+      redis:
+        image: redis:latest
+        ports:
+          - 6379:6379
+
     steps:
     - uses: actions/checkout@v4
     - name: Set up JDK 17

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
 
 	// 이메일 인증
 	implementation ("org.springframework.boot:spring-boot-starter-mail")
+	implementation("org.springframework.boot:spring-boot-starter-data-redis")
 
 	// 아임포트
 	implementation("com.github.iamport:iamport-rest-client-java:0.2.23")

--- a/src/main/java/com/pawland/PawLandApplication.java
+++ b/src/main/java/com/pawland/PawLandApplication.java
@@ -2,6 +2,7 @@ package com.pawland;
 
 import com.pawland.global.config.AppConfig;
 import com.pawland.global.config.MailConfig;
+import com.pawland.global.config.RedisConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
@@ -9,11 +10,11 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 
 @SpringBootApplication
 @EnableJpaAuditing
-@EnableConfigurationProperties({AppConfig.class, MailConfig.class})
+@EnableConfigurationProperties({AppConfig.class, MailConfig.class, RedisConfig.class})
 public class PawLandApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(PawLandApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(PawLandApplication.class, args);
+    }
 
 }

--- a/src/main/java/com/pawland/auth/controller/AuthController.java
+++ b/src/main/java/com/pawland/auth/controller/AuthController.java
@@ -6,6 +6,9 @@ import com.pawland.auth.dto.request.SendVerificationCodeRequest;
 import com.pawland.auth.facade.AuthFacade;
 import com.pawland.auth.dto.request.SignupRequest;
 import com.pawland.global.config.security.domain.LoginRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.mail.MessagingException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.io.UnsupportedEncodingException;
+import java.time.Duration;
 
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.OK;
@@ -29,6 +33,9 @@ public class AuthController {
 
     private final AuthFacade authFacade;
 
+    @Operation(summary = "이메일 중복 확인", description = "요청한 이메일이 이미 가입된 이메일인지 확인합니다.")
+    @ApiResponse(responseCode = "200", description = "사용할 수 있는 이메일")
+    @ApiResponse(responseCode = "400", description = "사용중인 이메일")
     @PostMapping(value = "/email-dupcheck", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity emailDupCheck(@Valid @RequestBody EmailDupCheckRequest request) {
         authFacade.checkEmailDuplicate(request.getEmail());
@@ -37,6 +44,9 @@ public class AuthController {
             .body("사용할 수 있는 이메일입니다.");
     }
 
+    @Operation(summary = "이메일로 인증번호 요청", description = "요청한 메일 주소로 인증번호가 담긴 메일을 발송 합니다.")
+    @ApiResponse(responseCode = "201", description = "인증번호 요청 성공")
+    @ApiResponse(responseCode = "500", description = "메일 전송 실패")
     @PostMapping(value = "/send-verification-code", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity sendVerificationCode(@Valid @RequestBody SendVerificationCodeRequest request) throws MessagingException, UnsupportedEncodingException {
         authFacade.sendVerificationCode(request.getEmail());
@@ -45,6 +55,9 @@ public class AuthController {
             .body("인증 메일이 발송 되었습니다.");
     }
 
+    @Operation(summary = "발급된 인증번호로 이메일 인증", description = "이메일과 인증번호를 확인하여 이메일을 인증합니다.")
+    @ApiResponse(responseCode = "200", description = "메일 인증 성공")
+    @ApiResponse(responseCode = "400", description = "잘못된 인증번호")
     @PostMapping(value = "/verify-code", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity verifyCode(@Valid @RequestBody VerifyCodeRequest request) {
         authFacade.verifyCode(request);
@@ -53,6 +66,11 @@ public class AuthController {
             .body("이메일 인증이 완료되었습니다.");
     }
 
+    @Operation(summary = "회원가입", description = "회원가입 성공 시 쿠키를 반환합니다.")
+    @ApiResponse(responseCode = "201", description = "회원가입 성공",
+        headers = {
+            @Header(name = "Set-Cookie", description = "인증 쿠키")
+        })
     @PostMapping(value = "/signup", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity signup(@Valid @RequestBody SignupRequest request) {
         authFacade.signup(request);
@@ -61,8 +79,14 @@ public class AuthController {
             .body("회원가입 되었습니다.");
     }
 
+    @Operation(summary = "로그인", description = "로그인 성공 시 쿠키를 반환합니다.")
+    @ApiResponse(responseCode = "200", description = "로그인에 성공",
+        headers = {
+            @Header(name = "Set-Cookie", description = "인증 쿠키")
+        })
+    @ApiResponse(responseCode = "400", description = "잘못된 아이디 혹은 비밀번호")
     @PostMapping(value = "/login", produces = MediaType.APPLICATION_JSON_VALUE)
     public void login(@Valid @RequestBody LoginRequest request) {
-        
+
     }
 }

--- a/src/main/java/com/pawland/auth/controller/AuthController.java
+++ b/src/main/java/com/pawland/auth/controller/AuthController.java
@@ -47,7 +47,7 @@ public class AuthController {
 
     @PostMapping(value = "/verify-code", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity verifyCode(@Valid @RequestBody VerifyCodeRequest request) {
-        authFacade.verifyCode(request.getCode());
+        authFacade.verifyCode(request);
         return ResponseEntity
             .status(OK)
             .body("이메일 인증이 완료되었습니다.");

--- a/src/main/java/com/pawland/auth/dto/request/VerifyCodeRequest.java
+++ b/src/main/java/com/pawland/auth/dto/request/VerifyCodeRequest.java
@@ -2,6 +2,7 @@ package com.pawland.auth.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -12,8 +13,13 @@ public class VerifyCodeRequest {
     @NotBlank(message = "인증 번호를 입력해주세요.")
     private String code;
 
-    public VerifyCodeRequest(String code) {
+    @NotBlank(message = "이메일을 입력해주세요.")
+    private String email;
+
+    @Builder
+    public VerifyCodeRequest(String code, String email) {
         this.code = code;
+        this.email = email;
     }
 }
 

--- a/src/main/java/com/pawland/auth/facade/AuthFacade.java
+++ b/src/main/java/com/pawland/auth/facade/AuthFacade.java
@@ -1,6 +1,7 @@
 package com.pawland.auth.facade;
 
 import com.pawland.auth.dto.request.SignupRequest;
+import com.pawland.auth.dto.request.VerifyCodeRequest;
 import com.pawland.mail.service.MailVerificationService;
 import com.pawland.user.domain.User;
 import com.pawland.user.service.UserService;
@@ -24,7 +25,7 @@ public class AuthFacade {
     }
 
     public void sendVerificationCode(String email) throws MessagingException, UnsupportedEncodingException {
-        mailVerificationService.sendEmail(email);
+        mailVerificationService.sendVerificationCode(email);
     }
 
     public void signup(SignupRequest request) {
@@ -36,7 +37,7 @@ public class AuthFacade {
         userService.register(user);
     }
 
-    public void verifyCode(String code) {
-
+    public void verifyCode(VerifyCodeRequest request) {
+        mailVerificationService.verifyCode(request.getEmail(), request.getCode());
     }
 }

--- a/src/main/java/com/pawland/auth/facade/AuthFacade.java
+++ b/src/main/java/com/pawland/auth/facade/AuthFacade.java
@@ -28,6 +28,10 @@ public class AuthFacade {
         mailVerificationService.sendVerificationCode(email);
     }
 
+    public void verifyCode(VerifyCodeRequest request) {
+        mailVerificationService.verifyCode(request.getEmail(), request.getCode());
+    }
+
     public void signup(SignupRequest request) {
         User user = User.builder()
             .email(request.getEmail())
@@ -35,9 +39,5 @@ public class AuthFacade {
             .phoneNumber(request.getPhoneNumber())
             .build();
         userService.register(user);
-    }
-
-    public void verifyCode(VerifyCodeRequest request) {
-        mailVerificationService.verifyCode(request.getEmail(), request.getCode());
     }
 }

--- a/src/main/java/com/pawland/global/config/RedisConfig.java
+++ b/src/main/java/com/pawland/global/config/RedisConfig.java
@@ -1,0 +1,38 @@
+package com.pawland.global.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Slf4j
+@EnableRedisRepositories
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "spring.redis")
+public class RedisConfig {
+
+    private final String host;
+    private final int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(host, port);
+        connectionFactory.start();
+        return connectionFactory;
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+
+}

--- a/src/main/java/com/pawland/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/pawland/global/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.pawland.global.exception;
 
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -26,6 +27,7 @@ public class GlobalExceptionHandler {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(MethodArgumentNotValidException.class)
     @RequestMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponse(responseCode = "400", description = "입력 값이 올바르지 않습니다.")
     public ResponseEntity invalidRequestHandler(MethodArgumentNotValidException e) {
         String[] errorMessages = e.getFieldErrors().stream()
             .map(fieldError -> fieldError.getDefaultMessage())
@@ -39,6 +41,7 @@ public class GlobalExceptionHandler {
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(MailSendException.class)
     @RequestMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponse(responseCode = "500",description = "메시지 전송 오류")
     public ResponseEntity mailSendExceptionHandler(MailSendException e) {
         return ResponseEntity
             .status(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/java/com/pawland/global/exception/InvalidCodeException.java
+++ b/src/main/java/com/pawland/global/exception/InvalidCodeException.java
@@ -1,0 +1,17 @@
+package com.pawland.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class InvalidCodeException extends PawLandException{
+
+    private static final String MESSAGE = "인증번호를 확인해주세요.";
+
+    public InvalidCodeException() {
+        super(MESSAGE);
+    }
+
+    @Override
+    public int getStatusCode() {
+        return HttpStatus.BAD_REQUEST.value();
+    }
+}

--- a/src/main/java/com/pawland/mail/service/MailVerificationService.java
+++ b/src/main/java/com/pawland/mail/service/MailVerificationService.java
@@ -1,29 +1,39 @@
 package com.pawland.mail.service;
 
 import com.pawland.global.config.MailConfig;
+import com.pawland.global.exception.InvalidCodeException;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.mail.MailSendException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.io.UnsupportedEncodingException;
+import java.time.Duration;
 import java.util.Random;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class MailVerificationService implements MailService {
+@Transactional(readOnly = true)
+public class MailVerificationService {
 
     private final MailConfig mailConfig;
     private final JavaMailSender mailSender;
+    private final RedisTemplate<String, String> redisTemplate;
 
-    @Override
-    public void sendEmail(String toEmail) throws MessagingException, UnsupportedEncodingException {
-        MimeMessage message = createEmailVerificationMessage(toEmail);
+    @Transactional
+    public void sendVerificationCode(String toEmail) throws MessagingException, UnsupportedEncodingException {
+        String verificationCode = generateVerificationCode();
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+        values.set(toEmail, verificationCode, Duration.ofMinutes(3));
+        MimeMessage message = createMessage(toEmail, verificationCode);
         try {
             mailSender.send(message);
         } catch (RuntimeException e) {
@@ -32,30 +42,42 @@ public class MailVerificationService implements MailService {
         }
     }
 
-    private MimeMessage createEmailVerificationMessage(String toEmail) throws MessagingException, UnsupportedEncodingException {
-        MimeMessage message = mailSender.createMimeMessage();
-        MimeMessageHelper helper = new MimeMessageHelper(message);
-        helper.setFrom(mailConfig.getFromEmail(), "나는짱");
-        helper.setTo(toEmail);
-        helper.setSubject("PAWLAND 이메일 인증");
-        String template = createTemplate();
-        helper.setText(template, true);
-        return message;
-    }
-
-    private String createTemplate() {
-        String template = "<html><body>";
-        template += "<p>안녕하세요, PAWLAND입니다.</p>";
-        template += "<p>인증 번호는 아래와 같습니다:</p>";
-        template += "<h2>" + generateVerificationCode() + "</h2>";
-        template += "<p>이 인증 번호를 입력하여 인증을 완료해주세요.</p>";
-        template += "</body></html>";
-        return template;
+    public void verifyCode(String toEmail, String code) {
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+        String savedVerificationCode = values.get(toEmail);
+        boolean isVerified = code.equals(savedVerificationCode);
+        if (isVerified) {
+            values.set(toEmail, "ok", Duration.ofMinutes(5));
+        } else {
+            log.error("[메일 인증 실패]");
+            throw new InvalidCodeException();
+        }
     }
 
     private String generateVerificationCode() {
         Random random = new Random();
         int randomNumber = random.nextInt(999999) + 1;
         return String.format("%06d", randomNumber);
+    }
+
+    private MimeMessage createMessage(String toEmail, String verificationCode) throws MessagingException, UnsupportedEncodingException {
+        MimeMessage message = mailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(message);
+        helper.setFrom(mailConfig.getFromEmail(), "나는짱");
+        helper.setTo(toEmail);
+        helper.setSubject("PAWLAND 이메일 인증");
+        String template = createTemplate(verificationCode);
+        helper.setText(template, true);
+        return message;
+    }
+
+    private String createTemplate(String verificationCode) {
+        String template = "<html><body>";
+        template += "<p>안녕하세요, PAWLAND입니다.</p>";
+        template += "<p>인증 번호는 아래와 같습니다:</p>";
+        template += "<h2>" + verificationCode + "</h2>";
+        template += "<p>이 인증 번호를 입력하여 인증을 완료해주세요.</p>";
+        template += "</body></html>";
+        return template;
     }
 }

--- a/src/test/java/com/pawland/mail/service/MailVerificationServiceTest.java
+++ b/src/test/java/com/pawland/mail/service/MailVerificationServiceTest.java
@@ -1,6 +1,7 @@
 package com.pawland.mail.service;
 
 import com.pawland.global.config.MailConfig;
+import com.pawland.global.exception.InvalidCodeException;
 import jakarta.mail.MessagingException;
 import jakarta.mail.Session;
 import jakarta.mail.internet.MimeMessage;
@@ -9,12 +10,15 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.mail.MailAuthenticationException;
 import org.springframework.mail.MailSendException;
 import org.springframework.mail.javamail.JavaMailSender;
 
 import java.io.UnsupportedEncodingException;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
@@ -28,6 +32,9 @@ class MailVerificationServiceTest {
     private JavaMailSender mailSender;
 
     @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Autowired
     private MailVerificationService mailVerificationService;
 
     @DisplayName("이메일 전송 성공 Mock 테스트")
@@ -39,7 +46,7 @@ class MailVerificationServiceTest {
         when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
 
         // when
-        mailVerificationService.sendEmail(toEmail);
+        mailVerificationService.sendVerificationCode(toEmail);
 
         // then
         verify(mailSender).send(mimeMessage);
@@ -58,8 +65,77 @@ class MailVerificationServiceTest {
             .send(mimeMessage);
 
         // expected
-        assertThatThrownBy(() -> mailVerificationService.sendEmail(toEmail))
+        assertThatThrownBy(() -> mailVerificationService.sendVerificationCode(toEmail))
             .isInstanceOf(MailSendException.class)
             .hasMessage("메일 전송에 실패했습니다.");
+    }
+
+    @DisplayName("이메일 전송 성공 시 인증 번호가 redis에 저장된다.")
+    @Test
+    void sendEmail3() throws MessagingException, UnsupportedEncodingException {
+        // given
+        String toEmail = "test@example.com";
+        MimeMessage mimeMessage = new MimeMessage((Session) null);
+        when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
+
+        // when
+        mailVerificationService.sendVerificationCode(toEmail);
+        String result = redisTemplate.opsForValue().get(toEmail);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.length()).isEqualTo(6);
+    }
+
+    @DisplayName("올바른 인증번호를 입력하면 redis에 성공 여부를 저장한다.")
+    @Test
+    void verifyCode1() throws MessagingException, UnsupportedEncodingException {
+        // given
+        String toEmail = "test@example.com";
+        MimeMessage mimeMessage = new MimeMessage((Session) null);
+        when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
+
+        // when
+        mailVerificationService.sendVerificationCode(toEmail);
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+        String verificationCode = values.get(toEmail);
+        mailVerificationService.verifyCode(toEmail, verificationCode);
+        String result = values.get(toEmail);
+
+        // then
+        assertThat(result).isEqualTo("ok");
+    }
+
+    @DisplayName("틀린 인증번호를 입력하면 예외를 던진다.")
+    @Test
+    void verifyCode2() throws MessagingException, UnsupportedEncodingException {
+        // given
+        String toEmail = "test@example.com";
+        MimeMessage mimeMessage = new MimeMessage((Session) null);
+        when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
+
+        // when
+        mailVerificationService.sendVerificationCode(toEmail);
+        String verificationCode = "1234";
+        assertThatThrownBy(() -> mailVerificationService.verifyCode(toEmail, verificationCode))
+            .isInstanceOf(InvalidCodeException.class)
+            .hasMessage("인증번호를 확인해주세요.");
+    }
+
+    @DisplayName("메일 인증을 요청하지 않은 이메일로 인증 번호를 입력하면 예외를 던진다.")
+    @Test
+    void verifyCode3() throws MessagingException, UnsupportedEncodingException {
+        // given
+        String toEmail = "test@example.com";
+        String notRequestedEmail = "test2@example.com";
+        MimeMessage mimeMessage = new MimeMessage((Session) null);
+        when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
+
+        // when
+        mailVerificationService.sendVerificationCode(toEmail);
+        String verificationCode = "1234";
+        assertThatThrownBy(() -> mailVerificationService.verifyCode(notRequestedEmail, verificationCode))
+            .isInstanceOf(InvalidCodeException.class)
+            .hasMessage("인증번호를 확인해주세요.");
     }
 }


### PR DESCRIPTION
## 🛠️주요 변경 사항
- 메일로 발송한 인증번호를 Redis에 저장하여 3분 뒤에 자동으로 DB에서 제거되도록 설정했습니다.
- 인증번호 입력하여 메일과 인증번호가 올바르면 성공 응답을 보내는 로직을 구현했습니다.
- AuthController에 간단한 스웨거 설정을 해뒀습니다.

## 📣리뷰어가 꼭 알아야 하는 사항
- 레디스 설정을 위해 yml에 추가 환경변수 설정을 해둬서 로컬에서 빌드 시 실패할 수 있습니다.
- github secret에는 등록해뒀는데 로컬에서 빌드 실패하시면 DM으로 말씀 주시면 yml 설정 공유해드리겠습니다.

## ❗관련이슈
- closed: #6 
