### PR TITLE
feat: 회원가입과 이메일 인증 연동 / 회원가입 완료 시 jwt 발급 

### DIFF
--- a/src/main/java/com/pawland/auth/controller/AuthController.java
+++ b/src/main/java/com/pawland/auth/controller/AuthController.java
@@ -73,9 +73,19 @@ public class AuthController {
         })
     @PostMapping(value = "/signup", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity signup(@Valid @RequestBody SignupRequest request) {
-        authFacade.signup(request);
+        String jwt = authFacade.signup(request);
+
+        ResponseCookie cookie = ResponseCookie.from("jwt", jwt)
+            .domain("localhost")   // todo 서버 환경에 따라 설정파일로 분리해서 관리
+            .path("/")
+            .secure(false)
+            .maxAge(Duration.ofDays(30))  // 한달이 국룰
+            .sameSite("Strict")
+            .build();
+
         return ResponseEntity
             .status(CREATED)
+            .header(HttpHeaders.SET_COOKIE, cookie.toString())
             .body("회원가입 되었습니다.");
     }
 

--- a/src/main/java/com/pawland/auth/controller/AuthController.java
+++ b/src/main/java/com/pawland/auth/controller/AuthController.java
@@ -79,7 +79,7 @@ public class AuthController {
             .domain("localhost")   // todo 서버 환경에 따라 설정파일로 분리해서 관리
             .path("/")
             .secure(false)
-            .maxAge(Duration.ofDays(30))  // 한달이 국룰
+            .maxAge(Duration.ofDays(30))
             .sameSite("Strict")
             .build();
 

--- a/src/main/java/com/pawland/auth/dto/request/SignupRequest.java
+++ b/src/main/java/com/pawland/auth/dto/request/SignupRequest.java
@@ -2,7 +2,6 @@ package com.pawland.auth.dto.request;
 
 import lombok.*;
 import jakarta.validation.constraints.NotBlank;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -15,17 +14,13 @@ public class SignupRequest {
     @NotBlank(message = "비밀번호를 입력해주세요.")
     private String password;
 
-    @NotBlank(message = "전화번호를 입력해주세요.")
-    private String phoneNumber;
+    @NotBlank(message = "닉네임을 입력해주세요.")
+    private String nickname;
 
     @Builder
-    public SignupRequest(String email, String password, String phoneNumber) {
+    public SignupRequest(String email, String password, String nickname) {
         this.email = email;
         this.password = password;
-        this.phoneNumber = phoneNumber;
-    }
-
-    public void encodePassword(PasswordEncoder passwordEncoder) {
-        this.password = passwordEncoder.encode(password);
+        this.nickname = nickname;
     }
 }

--- a/src/main/java/com/pawland/auth/facade/AuthFacade.java
+++ b/src/main/java/com/pawland/auth/facade/AuthFacade.java
@@ -36,7 +36,7 @@ public class AuthFacade {
         User user = User.builder()
             .email(request.getEmail())
             .password(passwordEncoder.encode(request.getPassword()))
-            .phoneNumber(request.getPhoneNumber())
+            .nickname(request.getNickname())
             .build();
         userService.register(user);
     }

--- a/src/main/java/com/pawland/auth/facade/AuthFacade.java
+++ b/src/main/java/com/pawland/auth/facade/AuthFacade.java
@@ -33,6 +33,7 @@ public class AuthFacade {
     }
 
     public void signup(SignupRequest request) {
+        mailVerificationService.checkEmailVerification(request.getEmail());
         User user = User.builder()
             .email(request.getEmail())
             .password(passwordEncoder.encode(request.getPassword()))

--- a/src/main/java/com/pawland/auth/facade/AuthFacade.java
+++ b/src/main/java/com/pawland/auth/facade/AuthFacade.java
@@ -2,6 +2,7 @@ package com.pawland.auth.facade;
 
 import com.pawland.auth.dto.request.SignupRequest;
 import com.pawland.auth.dto.request.VerifyCodeRequest;
+import com.pawland.global.config.security.JwtUtils;
 import com.pawland.mail.service.MailVerificationService;
 import com.pawland.user.domain.User;
 import com.pawland.user.service.UserService;
@@ -11,6 +12,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
 import java.io.UnsupportedEncodingException;
+import java.util.Date;
 
 @Component
 @RequiredArgsConstructor
@@ -19,6 +21,7 @@ public class AuthFacade {
     private final UserService userService;
     private final MailVerificationService mailVerificationService;
     private final PasswordEncoder passwordEncoder;
+    private final JwtUtils jwtUtils;
 
     public void checkEmailDuplicate(String email) {
         userService.checkEmailDuplicate(email);
@@ -32,7 +35,7 @@ public class AuthFacade {
         mailVerificationService.verifyCode(request.getEmail(), request.getCode());
     }
 
-    public void signup(SignupRequest request) {
+    public String signup(SignupRequest request) {
         mailVerificationService.checkEmailVerification(request.getEmail());
         User user = User.builder()
             .email(request.getEmail())
@@ -40,5 +43,8 @@ public class AuthFacade {
             .nickname(request.getNickname())
             .build();
         userService.register(user);
+
+        return jwtUtils.generateAccessToken(request.getEmail(), new Date());
     }
+
 }

--- a/src/main/java/com/pawland/global/config/SwaggerConfig.java
+++ b/src/main/java/com/pawland/global/config/SwaggerConfig.java
@@ -10,16 +10,16 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @SecurityScheme(
-        name = "cookie",
-        type = SecuritySchemeType.APIKEY,
-        in = SecuritySchemeIn.HEADER
+    name = "cookie",
+    type = SecuritySchemeType.APIKEY,
+    in = SecuritySchemeIn.HEADER
 )
 public class SwaggerConfig {
 
     @Bean
     public OpenAPI serverApiConfig() {
         return new OpenAPI()
-                .info(new Info().title("PAWLAND API")
-                        .description("PAWLAND API SWAGGER UI입니다."));
+            .info(new Info().title("PAWLAND API")
+                .description("PAWLAND API SWAGGER UI입니다."));
     }
 }

--- a/src/main/java/com/pawland/global/config/security/JwtUtils.java
+++ b/src/main/java/com/pawland/global/config/security/JwtUtils.java
@@ -37,7 +37,7 @@ public class JwtUtils {
         return Jwts.builder()
             .subject(name)
             .issuedAt(dateTime)
-            .expiration(new Date(dateTime.getTime() + 36000L)) // 한달짜리 jwt
+            .expiration(new Date(dateTime.getTime() + 24L * 60 * 60 * 1000)) // 하루짜리 jwt
             .signWith(secretKey)
             .compact();
     }

--- a/src/main/java/com/pawland/global/exception/InvalidUserException.java
+++ b/src/main/java/com/pawland/global/exception/InvalidUserException.java
@@ -1,0 +1,17 @@
+package com.pawland.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class InvalidUserException extends PawLandException{
+
+    private static final String MESSAGE = "이메일 인증이 인증되지 않은 유저입니다.";
+
+    public InvalidUserException() {
+        super(MESSAGE);
+    }
+
+    @Override
+    public int getStatusCode() {
+        return HttpStatus.UNAUTHORIZED.value();
+    }
+}

--- a/src/main/java/com/pawland/user/domain/User.java
+++ b/src/main/java/com/pawland/user/domain/User.java
@@ -33,10 +33,8 @@ public class User {
     @NotBlank(message = "비밀번호를 입력해주세요.")
     private String password;   // 비밀번호
 
-    @NotBlank(message = "전화번호를 입력해주세요.")
-    private String phoneNumber;    // 전화번호
-
-    private String name;     // 이름(닉네임)
+    @NotBlank(message = "닉네임을 입력해주세요.")
+    private String nickname;    // 전화번호
 
     private String introduce;   // 소개
 
@@ -63,14 +61,18 @@ public class User {
     private List<FavoritePost> favoritePostList = new ArrayList<>();    // 추천 누른 글
 
     @Builder
-    public User(String email, String password, String name, String introduce, UserType type, String phoneNumber, boolean emailVerified, String image) {
+    public User(String email, String password, String introduce, UserType type, String nickname, boolean emailVerified, String image) {
         this.email = email;
         this.password = password;
-        this.name = name;
         this.introduce = introduce;
         this.type = type;
-        this.phoneNumber = phoneNumber;
+        this.nickname = nickname;
         this.emailVerified = emailVerified;
         this.image = image;
+    }
+
+    @Deprecated
+    public String getName() {
+        return nickname;
     }
 }

--- a/src/main/java/com/pawland/user/domain/User.java
+++ b/src/main/java/com/pawland/user/domain/User.java
@@ -41,8 +41,6 @@ public class User {
     @Enumerated(EnumType.STRING)    // 회원 유형(구글, 카카오, 일반)
     private UserType type = NORMAL;
 
-    private boolean emailVerified = false;    // 이메일 인증 여부
-
     private String image;    // 이미지
 
     @OneToMany(mappedBy = "buyer")
@@ -61,13 +59,12 @@ public class User {
     private List<FavoritePost> favoritePostList = new ArrayList<>();    // 추천 누른 글
 
     @Builder
-    public User(String email, String password, String introduce, UserType type, String nickname, boolean emailVerified, String image) {
+    public User(String email, String password, String introduce, UserType type, String nickname, String image) {
         this.email = email;
         this.password = password;
         this.introduce = introduce;
         this.type = type;
         this.nickname = nickname;
-        this.emailVerified = emailVerified;
         this.image = image;
     }
 

--- a/src/main/java/com/pawland/user/dto/UserResponse.java
+++ b/src/main/java/com/pawland/user/dto/UserResponse.java
@@ -7,16 +7,16 @@ import lombok.Data;
 public class UserResponse {
     private Long id;
     private String email;
-    private String name;
+    private String nickname;
 
-    private UserResponse(Long id, String email, String name) {
+    private UserResponse(Long id, String email, String nickname) {
         this.id = id;
         this.email = email;
-        this.name = name;
+        this.nickname = nickname;
     }
 
     public static UserResponse of(User user) {
-        return new UserResponse(user.getId(), user.getEmail(), user.getName());
+        return new UserResponse(user.getId(), user.getEmail(), user.getNickname());
     }
 
 

--- a/src/test/java/com/pawland/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/pawland/auth/controller/AuthControllerTest.java
@@ -91,7 +91,7 @@ class AuthControllerTest {
         User user = User.builder()
             .email("midcon@nav.com")
             .password("asd123123")
-            .phoneNumber("010-1234-5678")
+            .nickname("나는짱")
             .build();
         userRepository.save(user);
 
@@ -244,7 +244,7 @@ class AuthControllerTest {
         SignupRequest request = SignupRequest.builder()
             .email("midcon@nav.com")
             .password("1234")
-            .phoneNumber("010-1234-5678")
+            .nickname("나는짱")
             .build();
 
         String json = objectMapper.writeValueAsString(request);
@@ -276,7 +276,7 @@ class AuthControllerTest {
             )
             .andDo(print())
             .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$", Matchers.hasItems("전화번호를 입력해주세요.")));
+            .andExpect(jsonPath("$", Matchers.hasItems("닉네임을 입력해주세요.")));
     }
 
     @DisplayName("필수 정보를 여러개 누락하면 회원가입에 실패하고, 누락된 필드들의 메시지를 출력한다.")
@@ -296,7 +296,7 @@ class AuthControllerTest {
             )
             .andDo(print())
             .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$", Matchers.hasItems("비밀번호를 입력해주세요.", "전화번호를 입력해주세요.")));
+            .andExpect(jsonPath("$", Matchers.hasItems("비밀번호를 입력해주세요.", "닉네임을 입력해주세요.")));
     }
 
     @DisplayName("이미 가입된 이메일로 가입 시 회원가입에 실패한다.")
@@ -306,14 +306,14 @@ class AuthControllerTest {
         User user = User.builder()
             .email("midcon@nav.com")
             .password("asd123123")
-            .phoneNumber("010-1234-5678")
+            .nickname("나는짱")
             .build();
         userRepository.save(user);
 
         SignupRequest request = SignupRequest.builder()
             .email("midcon@nav.com")
             .password("asd123123")
-            .phoneNumber("010-1234-5678")
+            .nickname("나는짱")
             .build();
 
         String json = objectMapper.writeValueAsString(request);
@@ -335,7 +335,7 @@ class AuthControllerTest {
         User user = User.builder()
             .email("midcon@nav.com")
             .password(passwordEncoder.encode("asd123123"))
-            .phoneNumber("010-1234-5678")
+            .nickname("나는짱")
             .build();
         userRepository.save(user);
 
@@ -364,7 +364,7 @@ class AuthControllerTest {
         User user = User.builder()
             .email("midcon@nav.com")
             .password(passwordEncoder.encode("asd123"))
-            .phoneNumber("010-1234-5678")
+            .nickname("나는짱")
             .build();
         userRepository.save(user);
 
@@ -393,7 +393,7 @@ class AuthControllerTest {
         User user = User.builder()
             .email("midcon@nav.com")
             .password("asd123123")
-            .phoneNumber("010-1234-5678")
+            .nickname("나는짱")
             .build();
         userRepository.save(user);
 

--- a/src/test/java/com/pawland/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/pawland/auth/controller/AuthControllerTest.java
@@ -64,175 +64,187 @@ class AuthControllerTest {
         });
     }
 
-    @DisplayName("가입되지 않은 이메일로 중복 확인 시 성공 메시지를 반환한다.")
-    @Test
-    void emailDupCheck1() throws Exception {
-        // given
-        EmailDupCheckRequest request = new EmailDupCheckRequest("midcon@nav.com");
+    @DisplayName("이메일로 중복 확인 요청 시")
+    @Nested
+    class emailDupCheck {
+        @DisplayName("가입되지 않은 이메일로 중복 확인 시 성공 메시지를 반환한다.")
+        @Test
+        void emailDupCheck1() throws Exception {
+            // given
+            EmailDupCheckRequest request = new EmailDupCheckRequest("midcon@nav.com");
 
-        String json = objectMapper.writeValueAsString(request);
+            String json = objectMapper.writeValueAsString(request);
 
-        // expected
-        mockMvc.perform(post("/api/auth/email-dupcheck")
-                .contentType(APPLICATION_JSON)
-                .content(json)
-            )
-            .andDo(print())
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$").value("사용할 수 있는 이메일입니다."));
+            // expected
+            mockMvc.perform(post("/api/auth/email-dupcheck")
+                    .contentType(APPLICATION_JSON)
+                    .content(json)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").value("사용할 수 있는 이메일입니다."));
+        }
+
+        @DisplayName("이미 가입된 이메일로 중복 확인 시 오류 메시지를 반환한다.")
+        @Test
+        void emailDupCheck2() throws Exception {
+            // given
+            User user = User.builder()
+                .email("midcon@nav.com")
+                .password("asd123123")
+                .nickname("나는짱")
+                .build();
+            userRepository.save(user);
+
+            EmailDupCheckRequest request = new EmailDupCheckRequest("midcon@nav.com");
+
+            String json = objectMapper.writeValueAsString(request);
+
+            // expected
+            mockMvc.perform(post("/api/auth/email-dupcheck")
+                    .contentType(APPLICATION_JSON)
+                    .content(json)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$").value("이미 존재하는 유저입니다."));
+        }
     }
 
-    @DisplayName("이미 가입된 이메일로 중복 확인 시 오류 메시지를 반환한다.")
-    @Test
-    void emailDupCheck2() throws Exception {
-        // given
-        User user = User.builder()
-            .email("midcon@nav.com")
-            .password("asd123123")
-            .nickname("나는짱")
-            .build();
-        userRepository.save(user);
+    @DisplayName("인증 메일 요청 시")
+    @Nested
+    class sendVerificationCode {
+        @DisplayName("인증 메일 요청에 성공한다.")
+        @Test
+        void sendVerificationCode1() throws Exception {
+            // given
+            SendVerificationCodeRequest request = new SendVerificationCodeRequest("hyukkind@naver.com");
+            MimeMessage mimeMessage = new MimeMessage((Session) null);
+            when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
 
-        EmailDupCheckRequest request = new EmailDupCheckRequest("midcon@nav.com");
+            String json = objectMapper.writeValueAsString(request);
 
-        String json = objectMapper.writeValueAsString(request);
+            // expected
+            mockMvc.perform(post("/api/auth/send-verification-code")
+                    .accept(MediaType.APPLICATION_JSON)
+                    .contentType(APPLICATION_JSON)
+                    .content(json)
+                )
+                .andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$").value("인증 메일이 발송 되었습니다."));
+        }
 
-        // expected
-        mockMvc.perform(post("/api/auth/email-dupcheck")
-                .contentType(APPLICATION_JSON)
-                .content(json)
-            )
-            .andDo(print())
-            .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$").value("이미 존재하는 유저입니다."));
+        @DisplayName("인증 메일 요청에 실패 시 에러 메시지를 출력한다.")
+        @Test
+        void sendVerificationCode2() throws Exception {
+            // given
+            SendVerificationCodeRequest request = new SendVerificationCodeRequest("hyukkind@naver.com");
+            MimeMessage mimeMessage = new MimeMessage((Session) null);
+            when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
+            doThrow(new MailAuthenticationException("Authentication failed"))
+                .when(mailSender)
+                .send(mimeMessage);
+
+            String json = objectMapper.writeValueAsString(request);
+
+            // expected
+            mockMvc.perform(post("/api/auth/send-verification-code")
+                    .accept(MediaType.APPLICATION_JSON)
+                    .contentType(APPLICATION_JSON)
+                    .content(json)
+                )
+                .andDo(print())
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$").value("메일 전송에 실패했습니다."));
+        }
     }
 
-    @DisplayName("인증 메일 요청에 성공한다.")
-    @Test
-    void sendVerificationCode1() throws Exception {
-        // given
-        SendVerificationCodeRequest request = new SendVerificationCodeRequest("hyukkind@naver.com");
-        MimeMessage mimeMessage = new MimeMessage((Session) null);
-        when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
+    @DisplayName("인증번호로 인증 요청 시")
+    @Nested
+    class verifyCode {
+        @DisplayName("올바른 인증번호로 인증 요청 시 성공 메시지를 반환한다.")
+        @Test
+        void verifyCode1() throws Exception {
+            // given
+            String email = "test@example.com";
+            String verificationCode = "123456";
+            ValueOperations<String, String> values = redisTemplate.opsForValue();
+            values.set(email, verificationCode, Duration.ofMinutes(3));
 
-        String json = objectMapper.writeValueAsString(request);
+            VerifyCodeRequest request = VerifyCodeRequest.builder()
+                .email(email)
+                .code(verificationCode)
+                .build();
 
-        // expected
-        mockMvc.perform(post("/api/auth/send-verification-code")
-                .accept(MediaType.APPLICATION_JSON)
-                .contentType(APPLICATION_JSON)
-                .content(json)
-            )
-            .andDo(print())
-            .andExpect(status().isCreated())
-            .andExpect(jsonPath("$").value("인증 메일이 발송 되었습니다."));
-    }
+            String json = objectMapper.writeValueAsString(request);
 
-    @DisplayName("인증 메일 요청에 실패 시 에러 메시지를 출력한다.")
-    @Test
-    void sendVerificationCode2() throws Exception {
-        // given
-        SendVerificationCodeRequest request = new SendVerificationCodeRequest("hyukkind@naver.com");
-        MimeMessage mimeMessage = new MimeMessage((Session) null);
-        when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
-        doThrow(new MailAuthenticationException("Authentication failed"))
-            .when(mailSender)
-            .send(mimeMessage);
+            // expected
+            mockMvc.perform(post("/api/auth/verify-code")
+                    .accept(MediaType.APPLICATION_JSON)
+                    .contentType(APPLICATION_JSON)
+                    .content(json)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").value("이메일 인증이 완료되었습니다."));
+        }
 
-        String json = objectMapper.writeValueAsString(request);
+        @DisplayName("틀린 인증번호로 인증 요청 시 실패 메시지를 반환한다.")
+        @Test
+        void verifyCode2() throws Exception {
+            // given
+            String email = "test@example.com";
+            String verificationCode = "123456";
+            String WrongCode = "111111";
+            ValueOperations<String, String> values = redisTemplate.opsForValue();
+            values.set(email, verificationCode, Duration.ofMinutes(3));
 
-        // expected
-        mockMvc.perform(post("/api/auth/send-verification-code")
-                .accept(MediaType.APPLICATION_JSON)
-                .contentType(APPLICATION_JSON)
-                .content(json)
-            )
-            .andDo(print())
-            .andExpect(status().isInternalServerError())
-            .andExpect(jsonPath("$").value("메일 전송에 실패했습니다."));
-    }
+            VerifyCodeRequest request = VerifyCodeRequest.builder()
+                .email(email)
+                .code(WrongCode)
+                .build();
 
-    @DisplayName("올바른 인증번호로 인증 요청 시 성공 메시지를 반환한다.")
-    @Test
-    void verifyCode1() throws Exception {
-        // given
-        String email = "test@example.com";
-        String verificationCode = "123456";
-        ValueOperations<String, String> values = redisTemplate.opsForValue();
-        values.set(email, verificationCode, Duration.ofMinutes(3));
+            String json = objectMapper.writeValueAsString(request);
 
-        VerifyCodeRequest request = VerifyCodeRequest.builder()
-            .email(email)
-            .code(verificationCode)
-            .build();
+            // expected
+            mockMvc.perform(post("/api/auth/verify-code")
+                    .accept(MediaType.APPLICATION_JSON)
+                    .contentType(APPLICATION_JSON)
+                    .content(json)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$").value("인증번호를 확인해주세요."));
+        }
 
-        String json = objectMapper.writeValueAsString(request);
+        @DisplayName("메일 인증을 요청하지 않은 이메일로 인증번호 입력 시 실패 메시지를 반환한다.")
+        @Test
+        void verifyCode3() throws Exception {
+            // given
+            String email = "test@example.com";
+            String notRequestedEmail = "midcon@nav.com";
+            String verificationCode = "123456";
+            ValueOperations<String, String> values = redisTemplate.opsForValue();
+            values.set(email, verificationCode, Duration.ofMinutes(3));
 
-        // expected
-        mockMvc.perform(post("/api/auth/verify-code")
-                .accept(MediaType.APPLICATION_JSON)
-                .contentType(APPLICATION_JSON)
-                .content(json)
-            )
-            .andDo(print())
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$").value("이메일 인증이 완료되었습니다."));
-    }
+            VerifyCodeRequest request = VerifyCodeRequest.builder()
+                .email(notRequestedEmail)
+                .code(verificationCode)
+                .build();
 
-    @DisplayName("틀린 인증번호로 인증 요청 시 실패 메시지를 반환한다.")
-    @Test
-    void verifyCode2() throws Exception {
-        // given
-        String email = "test@example.com";
-        String verificationCode = "123456";
-        String WrongCode = "111111";
-        ValueOperations<String, String> values = redisTemplate.opsForValue();
-        values.set(email, verificationCode, Duration.ofMinutes(3));
+            String json = objectMapper.writeValueAsString(request);
 
-        VerifyCodeRequest request = VerifyCodeRequest.builder()
-            .email(email)
-            .code(WrongCode)
-            .build();
-
-        String json = objectMapper.writeValueAsString(request);
-
-        // expected
-        mockMvc.perform(post("/api/auth/verify-code")
-                .accept(MediaType.APPLICATION_JSON)
-                .contentType(APPLICATION_JSON)
-                .content(json)
-            )
-            .andDo(print())
-            .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$").value("인증번호를 확인해주세요."));
-    }
-
-    @DisplayName("메일 인증을 요청하지 않은 이메일로 인증번호 입력 시 실패 메시지를 반환한다.")
-    @Test
-    void verifyCode3() throws Exception {
-        // given
-        String email = "test@example.com";
-        String notRequestedEmail = "midcon@nav.com";
-        String verificationCode = "123456";
-        ValueOperations<String, String> values = redisTemplate.opsForValue();
-        values.set(email, verificationCode, Duration.ofMinutes(3));
-
-        VerifyCodeRequest request = VerifyCodeRequest.builder()
-            .email(notRequestedEmail)
-            .code(verificationCode)
-            .build();
-
-        String json = objectMapper.writeValueAsString(request);
-
-        // expected
-        mockMvc.perform(post("/api/auth/verify-code")
-                .accept(MediaType.APPLICATION_JSON)
-                .contentType(APPLICATION_JSON)
-                .content(json)
-            )
-            .andDo(print())
-            .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$").value("인증번호를 확인해주세요."));
+            // expected
+            mockMvc.perform(post("/api/auth/verify-code")
+                    .accept(MediaType.APPLICATION_JSON)
+                    .contentType(APPLICATION_JSON)
+                    .content(json)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$").value("인증번호를 확인해주세요."));
+        }
     }
 
     @DisplayName("회원가입 시")
@@ -256,7 +268,8 @@ class AuthControllerTest {
                 )
                 .andDo(print())
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$", Matchers.hasItems("닉네임을 입력해주세요.")));
+                .andExpect(jsonPath("$", Matchers.hasItems("닉네임을 입력해주세요.")))
+                .andExpect(cookie().doesNotExist("jwt"));
         }
 
         @DisplayName("필수 정보를 여러개 누락하면 회원가입에 실패하고, 누락된 필드들의 메시지를 출력한다.")
@@ -276,7 +289,8 @@ class AuthControllerTest {
                 )
                 .andDo(print())
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$", Matchers.hasItems("비밀번호를 입력해주세요.", "닉네임을 입력해주세요.")));
+                .andExpect(jsonPath("$", Matchers.hasItems("비밀번호를 입력해주세요.", "닉네임을 입력해주세요.")))
+                .andExpect(cookie().doesNotExist("jwt"));
         }
 
         @DisplayName("이메일 인증을 했을 때")
@@ -303,7 +317,8 @@ class AuthControllerTest {
                     )
                     .andDo(print())
                     .andExpect(status().isCreated())
-                    .andExpect(jsonPath("$").value("회원가입 되었습니다."));
+                    .andExpect(jsonPath("$").value("회원가입 되었습니다."))
+                    .andExpect(cookie().exists("jwt"));
             }
 
             @DisplayName("이미 가입된 이메일로 가입 시 회원가입에 실패한다.")
@@ -334,10 +349,10 @@ class AuthControllerTest {
                     )
                     .andDo(print())
                     .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$").value("이미 존재하는 유저입니다."));
+                    .andExpect(jsonPath("$").value("이미 존재하는 유저입니다."))
+                    .andExpect(cookie().doesNotExist("jwt"));
             }
         }
-
 
         @DisplayName("이메일 인증을 안했을 때")
         @Nested
@@ -361,7 +376,8 @@ class AuthControllerTest {
                     )
                     .andDo(print())
                     .andExpect(status().isUnauthorized())
-                    .andExpect(jsonPath("$").value("이메일 인증이 인증되지 않은 유저입니다."));
+                    .andExpect(jsonPath("$").value("이메일 인증이 인증되지 않은 유저입니다."))
+                    .andExpect(cookie().doesNotExist("jwt"));
             }
 
             @DisplayName("이미 가입된 이메일로 가입 시 회원가입에 실패한다.")
@@ -390,95 +406,100 @@ class AuthControllerTest {
                     )
                     .andDo(print())
                     .andExpect(status().isUnauthorized())
-                    .andExpect(jsonPath("$").value("이메일 인증이 인증되지 않은 유저입니다."));
+                    .andExpect(jsonPath("$").value("이메일 인증이 인증되지 않은 유저입니다."))
+                    .andExpect(cookie().doesNotExist("jwt"));
             }
         }
     }
 
-    @DisplayName("등록된 유저와 이메일, 비밀번호가 일치하면 로그인에 성공한다.")
-    @Test
-    void login1() throws Exception {
-        // given
-        User user = User.builder()
-            .email("midcon@nav.com")
-            .password(passwordEncoder.encode("asd123123"))
-            .nickname("나는짱")
-            .build();
-        userRepository.save(user);
+    @DisplayName("로그인 시")
+    @Nested
+    class login {
+        @DisplayName("등록된 유저와 이메일, 비밀번호가 일치하면 로그인에 성공한다.")
+        @Test
+        void login1() throws Exception {
+            // given
+            User user = User.builder()
+                .email("midcon@nav.com")
+                .password(passwordEncoder.encode("asd123123"))
+                .nickname("나는짱")
+                .build();
+            userRepository.save(user);
 
-        LoginRequest request = LoginRequest.builder()
-            .email("midcon@nav.com")
-            .password("asd123123")
-            .build();
+            LoginRequest request = LoginRequest.builder()
+                .email("midcon@nav.com")
+                .password("asd123123")
+                .build();
 
-        String json = objectMapper.writeValueAsString(request);
+            String json = objectMapper.writeValueAsString(request);
 
-        // expected
-        mockMvc.perform(post("/api/auth/login")
-                .contentType(APPLICATION_JSON)
-                .content(json)
-            )
-            .andDo(print())
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$").value("로그인에 성공했습니다."))
-            .andExpect(cookie().exists("jwt"));
-    }
+            // expected
+            mockMvc.perform(post("/api/auth/login")
+                    .contentType(APPLICATION_JSON)
+                    .content(json)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").value("로그인에 성공했습니다."))
+                .andExpect(cookie().exists("jwt"));
+        }
 
-    @DisplayName("틀린 비밀번호로 로그인 요청 시 로그인에 실패한다.")
-    @Test
-    void login2() throws Exception {
-        // given
-        User user = User.builder()
-            .email("midcon@nav.com")
-            .password(passwordEncoder.encode("asd123"))
-            .nickname("나는짱")
-            .build();
-        userRepository.save(user);
+        @DisplayName("틀린 비밀번호로 로그인 요청 시 로그인에 실패한다.")
+        @Test
+        void login2() throws Exception {
+            // given
+            User user = User.builder()
+                .email("midcon@nav.com")
+                .password(passwordEncoder.encode("asd123"))
+                .nickname("나는짱")
+                .build();
+            userRepository.save(user);
 
-        LoginRequest request = LoginRequest.builder()
-            .email("midcon@nav.com")
-            .password("asd123123")
-            .build();
+            LoginRequest request = LoginRequest.builder()
+                .email("midcon@nav.com")
+                .password("asd123123")
+                .build();
 
-        String json = objectMapper.writeValueAsString(request);
+            String json = objectMapper.writeValueAsString(request);
 
-        // expected
-        mockMvc.perform(post("/api/auth/login")
-                .contentType(APPLICATION_JSON)
-                .content(json)
-            )
-            .andDo(print())
-            .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$").value("아이디 혹은 비밀번호가 올바르지 않습니다."))
-            .andExpect(cookie().doesNotExist("jwt"));
-    }
+            // expected
+            mockMvc.perform(post("/api/auth/login")
+                    .contentType(APPLICATION_JSON)
+                    .content(json)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$").value("아이디 혹은 비밀번호가 올바르지 않습니다."))
+                .andExpect(cookie().doesNotExist("jwt"));
+        }
 
-    @DisplayName("등록되지 않는 이메일로 로그인 요청 시 로그인에 실패한다.")
-    @Test
-    void login3() throws Exception {
-        // given
-        User user = User.builder()
-            .email("midcon@nav.com")
-            .password("asd123123")
-            .nickname("나는짱")
-            .build();
-        userRepository.save(user);
+        @DisplayName("등록되지 않는 이메일로 로그인 요청 시 로그인에 실패한다.")
+        @Test
+        void login3() throws Exception {
+            // given
+            User user = User.builder()
+                .email("midcon@nav.com")
+                .password("asd123123")
+                .nickname("나는짱")
+                .build();
+            userRepository.save(user);
 
-        LoginRequest request = LoginRequest.builder()
-            .email("mid@nav.com")
-            .password("asd123123")
-            .build();
+            LoginRequest request = LoginRequest.builder()
+                .email("mid@nav.com")
+                .password("asd123123")
+                .build();
 
-        String json = objectMapper.writeValueAsString(request);
+            String json = objectMapper.writeValueAsString(request);
 
-        // expected
-        mockMvc.perform(post("/api/auth/login")
-                .contentType(APPLICATION_JSON)
-                .content(json)
-            )
-            .andDo(print())
-            .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$").value("아이디 혹은 비밀번호가 올바르지 않습니다."))
-            .andExpect(cookie().doesNotExist("jwt"));
+            // expected
+            mockMvc.perform(post("/api/auth/login")
+                    .contentType(APPLICATION_JSON)
+                    .content(json)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$").value("아이디 혹은 비밀번호가 올바르지 않습니다."))
+                .andExpect(cookie().doesNotExist("jwt"));
+        }
     }
 }

--- a/src/test/java/com/pawland/mail/service/MailVerificationServiceTest.java
+++ b/src/test/java/com/pawland/mail/service/MailVerificationServiceTest.java
@@ -152,7 +152,7 @@ class MailVerificationServiceTest {
             .hasMessage("인증번호를 확인해주세요.");
     }
 
-    @DisplayName("인증된 유저가 요청 시 성공한다.")
+    @DisplayName("이메일 인증된 유저가 회원가입 요청 시 성공한다.")
     @Test
     void checkEmailVerification1() {
         // given
@@ -169,7 +169,7 @@ class MailVerificationServiceTest {
         verify(values, times(1)).get(verifiedEmail);
     }
 
-    @DisplayName("인증되지 않은 유저가 요청 시 실패한다.")
+    @DisplayName("이메일을 인증하지 않은 유저가 회원가입 요청 시 실패한다.")
     @Test
     void checkEmailVerification2() {
         // given

--- a/src/test/java/com/pawland/mail/service/MailVerificationServiceTest.java
+++ b/src/test/java/com/pawland/mail/service/MailVerificationServiceTest.java
@@ -2,9 +2,11 @@ package com.pawland.mail.service;
 
 import com.pawland.global.config.MailConfig;
 import com.pawland.global.exception.InvalidCodeException;
+import com.pawland.global.exception.InvalidUserException;
 import jakarta.mail.MessagingException;
 import jakarta.mail.Session;
 import jakarta.mail.internet.MimeMessage;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,6 +39,18 @@ class MailVerificationServiceTest {
 
     @Autowired
     private MailVerificationService mailVerificationService;
+
+    private RedisTemplate<String, String> mockRedisTemplate;
+
+    private MailVerificationService mockMailService;
+
+    @BeforeEach
+    void setUp() {
+        mockRedisTemplate = mock(RedisTemplate.class);
+        ValueOperations<String, String> mockValues = mock(ValueOperations.class);
+        when(mockRedisTemplate.opsForValue()).thenReturn(mockValues);
+        mockMailService = new MailVerificationService(mailConfig, mailSender, mockRedisTemplate);
+    }
 
     @DisplayName("이메일 전송 성공 Mock 테스트")
     @Test
@@ -136,5 +150,52 @@ class MailVerificationServiceTest {
         assertThatThrownBy(() -> mailVerificationService.verifyCode(notRequestedEmail, verificationCode))
             .isInstanceOf(InvalidCodeException.class)
             .hasMessage("인증번호를 확인해주세요.");
+    }
+
+    @DisplayName("인증된 유저가 요청 시 성공한다.")
+    @Test
+    void checkEmailVerification1() {
+        // given
+        String verifiedEmail = "test@example.com";
+        String authSuccessStatus = "ok";
+        ValueOperations<String, String> values = mockRedisTemplate.opsForValue();
+        when(values.get(verifiedEmail)).thenReturn(authSuccessStatus);
+
+        // when
+        mockMailService.checkEmailVerification(verifiedEmail);
+
+        // then
+        verify(values).get(verifiedEmail);
+        verify(values, times(1)).get(verifiedEmail);
+    }
+
+    @DisplayName("인증되지 않은 유저가 요청 시 실패한다.")
+    @Test
+    void checkEmailVerification2() {
+        // given
+        String authWaitingEmail = "test@example.com";
+        String authWaitingStatus = "123456";
+        ValueOperations<String, String> values = mockRedisTemplate.opsForValue();
+        when(values.get(authWaitingEmail)).thenReturn(authWaitingStatus);
+
+        // expected
+        assertThatThrownBy(() ->  mockMailService.checkEmailVerification(authWaitingEmail))
+            .isInstanceOf(InvalidUserException.class)
+            .hasMessage("이메일 인증이 인증되지 않은 유저입니다.");
+    }
+
+    @DisplayName("인증 요청을 하지 않았거나 인증한지 오래된 유저가 요청 시 실패한다.")
+    @Test
+    void checkEmailVerification3() {
+        // given
+        String authNotProcessingEmail = "test@example.com";
+        String authNotProcessingStatus = null;
+        ValueOperations<String, String> values = mockRedisTemplate.opsForValue();
+        when(values.get(authNotProcessingEmail)).thenReturn(authNotProcessingStatus);
+
+        // expected
+        assertThatThrownBy(() ->  mockMailService.checkEmailVerification(authNotProcessingEmail))
+            .isInstanceOf(InvalidUserException.class)
+            .hasMessage("이메일 인증이 인증되지 않은 유저입니다.");
     }
 }

--- a/src/test/java/com/pawland/order/service/OrderServiceTest.java
+++ b/src/test/java/com/pawland/order/service/OrderServiceTest.java
@@ -37,8 +37,8 @@ class OrderServiceTest {
     void init() {
         User tester = User.builder().email("test@test.com")
                 .password("123123")
-                .phoneNumber("010-1111-1111")
-                .name("tester")
+                .nickname("010-1111-1111")
+                .nickname("tester")
                 .introduce("tester입니다.")
                 .type(UserType.GOOGLE)
                 .emailVerified(true).build();
@@ -49,8 +49,8 @@ class OrderServiceTest {
 
         User tester2 = User.builder().email("test2@test.com")
                 .password("123123")
-                .phoneNumber("010-1111-2222")
-                .name("tester2")
+                .nickname("010-1111-2222")
+                .nickname("tester2")
                 .introduce("tester2입니다.")
                 .type(UserType.GOOGLE)
                 .emailVerified(true).build();
@@ -81,8 +81,8 @@ class OrderServiceTest {
 
         //then
         Assertions.assertEquals(1L,orderResponse.getId());
-        Assertions.assertEquals(seller.getName(),orderResponse.getSeller().getName());
-        Assertions.assertEquals(buyer.getName(),orderResponse.getBuyer().getName());
+        Assertions.assertEquals(seller.getName(),orderResponse.getSeller().getNickname());
+        Assertions.assertEquals(buyer.getName(),orderResponse.getBuyer().getNickname());
         Assertions.assertEquals("상품1",orderResponse.getProduct().getName());
     }
 
@@ -99,8 +99,8 @@ class OrderServiceTest {
 
         //then
         Assertions.assertEquals(1L,oneOrderById.getId());
-        Assertions.assertEquals(seller.getName(),oneOrderById.getSeller().getName());
-        Assertions.assertEquals(buyer.getName(),oneOrderById.getBuyer().getName());
+        Assertions.assertEquals(seller.getName(),oneOrderById.getSeller().getNickname());
+        Assertions.assertEquals(buyer.getName(),oneOrderById.getBuyer().getNickname());
         Assertions.assertEquals("상품1",oneOrderById.getProduct().getName());
     }
 

--- a/src/test/java/com/pawland/order/service/OrderServiceTest.java
+++ b/src/test/java/com/pawland/order/service/OrderServiceTest.java
@@ -41,7 +41,7 @@ class OrderServiceTest {
                 .nickname("tester")
                 .introduce("tester입니다.")
                 .type(UserType.GOOGLE)
-                .emailVerified(true).build();
+                .build();
 
         userRepository.save(tester);
 
@@ -53,7 +53,7 @@ class OrderServiceTest {
                 .nickname("tester2")
                 .introduce("tester2입니다.")
                 .type(UserType.GOOGLE)
-                .emailVerified(true).build();
+                .build();
 
         userRepository.save(tester2);
 

--- a/src/test/java/com/pawland/product/service/ProductServiceTest.java
+++ b/src/test/java/com/pawland/product/service/ProductServiceTest.java
@@ -28,12 +28,13 @@ class ProductServiceTest {
 
     @PostConstruct
     void init() {
-        User tester = User.builder().email("test@test.com")
+        User tester = User.builder()
+            .email("test@test.com")
                 .password("123123")
                 .nickname("tester")
                 .introduce("tester입니다.")
                 .type(UserType.GOOGLE)
-                .emailVerified(true).build();
+                .build();
 
         userRepository.save(tester);
     }

--- a/src/test/java/com/pawland/product/service/ProductServiceTest.java
+++ b/src/test/java/com/pawland/product/service/ProductServiceTest.java
@@ -30,8 +30,7 @@ class ProductServiceTest {
     void init() {
         User tester = User.builder().email("test@test.com")
                 .password("123123")
-                .phoneNumber("010-1111-1111")
-                .name("tester")
+                .nickname("tester")
                 .introduce("tester입니다.")
                 .type(UserType.GOOGLE)
                 .emailVerified(true).build();
@@ -66,7 +65,7 @@ class ProductServiceTest {
 
         //then
         Assertions.assertEquals(1L, product.getId());
-        Assertions.assertEquals("tester",product.getSeller().getName());
+        Assertions.assertEquals("tester",product.getSeller().getNickname());
     }
 
 
@@ -82,7 +81,7 @@ class ProductServiceTest {
         //then
         Assertions.assertEquals(1L, oneProductById.getId());
         Assertions.assertEquals("상품1",oneProductById.getName());
-        Assertions.assertEquals("tester",oneProductById.getSeller().getName());
+        Assertions.assertEquals("tester",oneProductById.getSeller().getNickname());
     }
 
     @DisplayName("상품 수정")

--- a/src/test/java/com/pawland/user/service/UserServiceTest.java
+++ b/src/test/java/com/pawland/user/service/UserServiceTest.java
@@ -43,7 +43,7 @@ class UserServiceTest {
         User user = User.builder()
             .email("mid@nav.com")
             .password("asd123123")
-            .phoneNumber("010-1234-5678")
+            .nickname("나는짱")
             .build();
         userRepository.save(user);
 
@@ -60,7 +60,7 @@ class UserServiceTest {
         User user = User.builder()
             .email("mid@nav.com")
             .password("asd123123")
-            .phoneNumber("010-1234-5678")
+            .nickname("나는짱")
             .build();
 
         // when
@@ -70,8 +70,8 @@ class UserServiceTest {
 
         // then
         assertThat(result.getEmail()).isEqualTo(user.getEmail());
-        assertThat(result.getPhoneNumber()).isEqualTo(user.getPhoneNumber());
-        assertThat(result.getPhoneNumber()).isEqualTo(user.getPhoneNumber());
+        assertThat(result.getNickname()).isEqualTo(user.getNickname());
+        assertThat(result.getNickname()).isEqualTo(user.getNickname());
     }
 
     @DisplayName("정상적인 정보 입력 시 중복 이메일이 존재하면 실패한다.")
@@ -81,14 +81,14 @@ class UserServiceTest {
         User user = User.builder()
             .email("mid@nav.com")
             .password("asd123123")
-            .phoneNumber("010-1234-5678")
+            .nickname("나는짱")
             .build();
 
         userService.register(user);
         User duplicateUser = User.builder()
             .email("mid@nav.com")
             .password("asd123123")
-            .phoneNumber("010-1234-5678")
+            .nickname("나는짱")
             .build();
 
         // expected


### PR DESCRIPTION
## 🛠️주요 변경 사항
- #8 의 이메일 인증 기능과 회원가입을 연동했습니다.
- 회원가입 완료 시 jwt를 발급합니다.

## 📣리뷰어가 꼭 알아야 하는 사항
- 응답 값과 에러 메시지는 따로 수정해서 PR 올리겠습니다.
- 엔티티 필드명 변경에 따라 유저 엔티티의 getName()은 deprecated 처리 해뒀습니다.
  사용하고 계신 부분을 getNickname() 으로 변경해주시고 쓰는곳 없어지면 제거할게요.

## ❗관련이슈
- closed: #8 
