### PR TITLE
feat: 소셜 로그인 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,10 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("org.springframework.boot:spring-boot-starter-web")
 
+	// 소셜 로그인
+	implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
+	implementation ("org.springframework.boot:spring-boot-starter-webflux")
+
 	// AWS SDK
 	implementation(platform("software.amazon.awssdk:bom:2.25.35"))
 	implementation("software.amazon.awssdk:s3")

--- a/src/main/java/com/pawland/auth/controller/AuthController.java
+++ b/src/main/java/com/pawland/auth/controller/AuthController.java
@@ -16,10 +16,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.io.UnsupportedEncodingException;
 
@@ -92,5 +89,20 @@ public class AuthController {
     @PostMapping(value = "/login", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ApiMessageResponse> login(@Valid @RequestBody LoginRequest request) {
         return ResponseEntity.ok(new ApiMessageResponse(""));
+    }
+
+    @Operation(summary = "소셜 로그인", description = "소셜 로그인 성공 시 쿠키를 반환합니다.")
+    @ApiResponse(responseCode = "200", description = "로그인에 성공",
+        headers = {
+            @Header(name = "Set-Cookie", description = "인증 쿠키")
+        })
+    @ApiResponse(responseCode = "400", description = "잘못된 아이디 혹은 비밀번호")
+    @GetMapping("/oauth2/{provider}")
+    public ResponseEntity<ApiMessageResponse> oauth2Login(@PathVariable String provider, @RequestParam String code) {
+        String jwtCookie = authFacade.oauth2Login(code, provider);
+        return ResponseEntity
+            .status(CREATED)
+            .header(HttpHeaders.SET_COOKIE, jwtCookie)
+            .body(new ApiMessageResponse("소셜 로그인에 성공했습니다."));
     }
 }

--- a/src/main/java/com/pawland/auth/dto/response/OAuthAttributes.java
+++ b/src/main/java/com/pawland/auth/dto/response/OAuthAttributes.java
@@ -1,0 +1,79 @@
+package com.pawland.auth.dto.response;
+
+import com.pawland.user.domain.LoginType;
+import com.pawland.user.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.Map;
+
+@Getter
+@ToString
+public class OAuthAttributes {
+    private String nickname;
+    private String email;
+    private String profileImage;
+    private String provider;
+
+    @Builder
+    public OAuthAttributes(String nickname, String email, String profileImage, String provider) {
+        this.nickname = nickname;
+        this.email = email;
+        this.profileImage = profileImage;
+        this.provider = provider;
+    }
+
+    public static OAuthAttributes of(String providerName, Map<String, Object> attributes) throws IllegalArgumentException {
+        switch (providerName) {
+            case "카카오":
+                return ofKakao(providerName, attributes);
+            case "구글":
+                return ofGoogle(providerName, attributes);
+            case "네이버":
+                return ofNaver(providerName, attributes);
+            default:
+                throw new IllegalArgumentException("허용되지 않은 접근입니다.");
+        }
+    }
+
+    public User toUser() {
+        return User.builder()
+            .nickname(nickname)
+            .email(email)
+            .password("oauth2")
+            .profileImage(profileImage)
+            .type(LoginType.fromString(provider))
+            .build();
+    }
+
+    private static OAuthAttributes ofKakao(String providerName, Map<String, Object> attributes) {
+        Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, Object> profile = (Map<String, Object>) account.get("profile");
+        return OAuthAttributes.builder()
+            .nickname((String) profile.get("nickname"))
+            .email((String) account.get("email"))
+            .profileImage((String) profile.get("profile_image_url"))
+            .provider(providerName)
+            .build();
+    }
+
+    private static OAuthAttributes ofGoogle(String providerName, Map<String, Object> attributes) {
+        return OAuthAttributes.builder()
+            .nickname((String) attributes.get("name"))
+            .email((String) attributes.get("email"))
+            .profileImage((String) attributes.get("picture"))
+            .provider(providerName)
+            .build();
+    }
+
+    private static OAuthAttributes ofNaver(String providerName, Map<String, Object> attributes) {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+        return OAuthAttributes.builder()
+            .nickname((String) response.get("nickname"))
+            .email((String) response.get("email"))
+            .profileImage((String) response.get("profile_image"))
+            .provider(providerName)
+            .build();
+    }
+}

--- a/src/main/java/com/pawland/auth/dto/response/OAuthAttributes.java
+++ b/src/main/java/com/pawland/auth/dto/response/OAuthAttributes.java
@@ -11,6 +11,8 @@ import java.util.Map;
 @Getter
 @ToString
 public class OAuthAttributes {
+
+    private static final String TEMP_NICKNAME = "임시 닉네임";
     private String nickname;
     private String email;
     private String profileImage;
@@ -51,8 +53,8 @@ public class OAuthAttributes {
         Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
         Map<String, Object> profile = (Map<String, Object>) account.get("profile");
         return OAuthAttributes.builder()
-            .nickname((String) profile.get("nickname"))
-            .email((String) account.get("email"))
+            .nickname(TEMP_NICKNAME)
+            .email(account.get("email") + "/" + providerName)
             .profileImage((String) profile.get("profile_image_url"))
             .provider(providerName)
             .build();
@@ -60,8 +62,8 @@ public class OAuthAttributes {
 
     private static OAuthAttributes ofGoogle(String providerName, Map<String, Object> attributes) {
         return OAuthAttributes.builder()
-            .nickname((String) attributes.get("name"))
-            .email((String) attributes.get("email"))
+            .nickname(TEMP_NICKNAME)
+            .email(attributes.get("email") + "/" + providerName)
             .profileImage((String) attributes.get("picture"))
             .provider(providerName)
             .build();
@@ -70,8 +72,8 @@ public class OAuthAttributes {
     private static OAuthAttributes ofNaver(String providerName, Map<String, Object> attributes) {
         Map<String, Object> response = (Map<String, Object>) attributes.get("response");
         return OAuthAttributes.builder()
-            .nickname((String) response.get("nickname"))
-            .email((String) response.get("email"))
+            .nickname(TEMP_NICKNAME)
+            .email(response.get("email") + "/" + providerName)
             .profileImage((String) response.get("profile_image"))
             .provider(providerName)
             .build();

--- a/src/main/java/com/pawland/auth/dto/response/OauthTokenResponse.java
+++ b/src/main/java/com/pawland/auth/dto/response/OauthTokenResponse.java
@@ -1,0 +1,24 @@
+package com.pawland.auth.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@NoArgsConstructor
+public class OauthTokenResponse {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @Builder
+    public OauthTokenResponse(String accessToken, String tokenType) {
+        this.accessToken = accessToken;
+        this.tokenType = tokenType;
+    }
+}

--- a/src/main/java/com/pawland/auth/facade/AuthFacade.java
+++ b/src/main/java/com/pawland/auth/facade/AuthFacade.java
@@ -2,6 +2,7 @@ package com.pawland.auth.facade;
 
 import com.pawland.auth.dto.request.SignupRequest;
 import com.pawland.auth.dto.request.VerifyCodeRequest;
+import com.pawland.auth.service.AuthService;
 import com.pawland.global.config.security.JwtUtils;
 import com.pawland.mail.service.MailVerificationService;
 import com.pawland.user.domain.User;
@@ -22,6 +23,7 @@ public class AuthFacade {
     private final MailVerificationService mailVerificationService;
     private final PasswordEncoder passwordEncoder;
     private final JwtUtils jwtUtils;
+    private final AuthService authService;
 
     public void checkEmailDuplicate(String email) {
         userService.checkEmailDuplicate(email);
@@ -43,8 +45,11 @@ public class AuthFacade {
             .nickname(request.getNickname())
             .build();
         userService.register(user);
-
         return jwtUtils.generateJwtCookie(request.getEmail(), new Date());
     }
 
+    public String oauth2Login(String code, String provider) {
+        User user = authService.oauth2Login(code, provider);
+        return jwtUtils.generateJwtCookie(user.getEmail(), new Date());
+    }
 }

--- a/src/main/java/com/pawland/auth/service/AuthService.java
+++ b/src/main/java/com/pawland/auth/service/AuthService.java
@@ -1,11 +1,72 @@
 package com.pawland.auth.service;
 
+import com.pawland.auth.dto.response.OAuthAttributes;
+import com.pawland.auth.dto.response.OauthTokenResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.WebClient;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuthService {
 
+    private final ClientRegistrationRepository clientRegistrationRepository;
 
+    public OAuthAttributes getUserInfoByOauth2(String code, String provider) {
+        ClientRegistration registration = clientRegistrationRepository.findByRegistrationId(provider);
+        OauthTokenResponse tokenResponse = requestAccessToken(code, registration);
+        return getUerProfile(tokenResponse.getAccessToken(), registration);
+    }
+
+    private OauthTokenResponse requestAccessToken(String code, ClientRegistration registration) {
+        return WebClient.create()
+            .post()
+            .uri(registration.getProviderDetails().getTokenUri())
+            .headers(header -> {
+                header.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+                header.setAcceptCharset(Collections.singletonList(StandardCharsets.UTF_8));
+            })
+            .bodyValue(createTokenRequest(code, registration))
+            .retrieve()
+            .bodyToMono(OauthTokenResponse.class)
+            .block();
+    }
+
+    private MultiValueMap<String, String> createTokenRequest(String code, ClientRegistration registration) {
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("code", code);
+        formData.add("grant_type", "authorization_code");
+        formData.add("redirect_uri", registration.getRedirectUri());
+        formData.add("client_secret", registration.getClientSecret());
+        formData.add("client_id", registration.getClientId());
+        return formData;
+    }
+
+    private OAuthAttributes getUerProfile(String accessToken, ClientRegistration registration) {
+        Map<String, Object> userAttributes = requestUserAttributes(registration, accessToken);
+        String clientName = registration.getClientName();
+        return OAuthAttributes.of(clientName, userAttributes);
+    }
+
+    private Map<String, Object> requestUserAttributes(ClientRegistration registration, String accessToken) {
+        return WebClient.create()
+            .get()
+            .uri(registration.getProviderDetails().getUserInfoEndpoint().getUri())
+            .headers(header -> header.setBearerAuth(accessToken))
+            .retrieve()
+            .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
+            .block();
+    }
 }

--- a/src/main/java/com/pawland/user/domain/LoginType.java
+++ b/src/main/java/com/pawland/user/domain/LoginType.java
@@ -3,6 +3,8 @@ package com.pawland.user.domain;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Arrays;
+
 @Getter
 @RequiredArgsConstructor
 public enum LoginType {
@@ -13,4 +15,18 @@ public enum LoginType {
     NORMAL("일반");
 
     private final String type;
+
+    public String value() {
+        return type;
+    }
+
+    public static LoginType fromString(String input) {
+        if (input == null || input.isBlank()) {
+            return LoginType.NORMAL;
+        }
+        return Arrays.stream(LoginType.values()).
+            filter(region -> region.value().equals(input))
+            .findFirst()
+            .orElseThrow(()-> new IllegalArgumentException("지역 값을 확인해주세요."));  // TODO: 커스텀 예외로 만들어도 될듯
+    }
 }

--- a/src/main/java/com/pawland/user/domain/User.java
+++ b/src/main/java/com/pawland/user/domain/User.java
@@ -68,6 +68,11 @@ public class User extends BaseTimeEntity {
         this.introduce = isBlank(user.getIntroduce()) ? introduce : user.getIntroduce();
     }
 
+    public User updateOauth2Profile(User user) {
+        this.profileImage = user.profileImage;
+        return this;
+    }
+
     private boolean isBlank(String value) {
         return value == null || value.isBlank();
     }


### PR DESCRIPTION
## 🛠️주요 변경 사항
- 구글/네이버/카카오 소셜 로그인을 추가했습니다.
- 소셜 로그인 후 JWT 발급까지 적용했습니다.
- 소셜 로그인과 일반 로그인의 유저의 이메일을 구분할 방법이 없어서 소셜 로그인일땐 이메일 뒤에 "/kakao" 이런 식으로 suffix를 붙이는 식으로 했습니다.
- 닉네임도 중복 안되게 하려고 Oauth2 유저 정보에서 주는 닉네임을 사용하지 않고 임시 닉네임으로 가입되게 해뒀는데 뒤에 랜덤번호 붙이는 식으로 수정해두겠습니다.

## 📣리뷰어가 꼭 알아야 하는 사항
- oauth2 설정 때문에 yml 파일 변경이 있어서 정상 동작하려면 yml 파일 적용해주셔야합니다.
- 당장은 client-id, secret을 제꺼로만 했는데 추후 수정 시 공유드리겠습니다.