### PR TITLE
feat: 닉네임 중복 확인 기능 구현

### DIFF
--- a/src/main/java/com/pawland/auth/controller/AuthController.java
+++ b/src/main/java/com/pawland/auth/controller/AuthController.java
@@ -1,10 +1,7 @@
 package com.pawland.auth.controller;
 
-import com.pawland.auth.dto.request.EmailDupCheckRequest;
-import com.pawland.auth.dto.request.VerifyCodeRequest;
-import com.pawland.auth.dto.request.SendVerificationCodeRequest;
+import com.pawland.auth.dto.request.*;
 import com.pawland.auth.facade.AuthFacade;
-import com.pawland.auth.dto.request.SignupRequest;
 import com.pawland.global.config.security.domain.LoginRequest;
 import com.pawland.global.dto.ApiMessageResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -31,6 +28,17 @@ import static org.springframework.http.HttpStatus.OK;
 public class AuthController {
 
     private final AuthFacade authFacade;
+
+    @Operation(summary = "닉네임 중복 확인", description = "요청한 닉네임이 이미 가입된 닉네임인지 확인합니다.")
+    @ApiResponse(responseCode = "200", description = "사용할 수 있는 닉네임")
+    @ApiResponse(responseCode = "400", description = "사용중인 닉네임")
+    @PostMapping(value = "/nickname-dupcheck", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<ApiMessageResponse> nicknameDupCheck(@Valid @RequestBody NicknameDupCheckRequest request) {
+        authFacade.checkNicknameDuplicate(request.getNickname());
+        return ResponseEntity
+            .status(OK)
+            .body(new ApiMessageResponse("사용할 수 있는 닉네임입니다."));
+    }
 
     @Operation(summary = "이메일 중복 확인", description = "요청한 이메일이 이미 가입된 이메일인지 확인합니다.")
     @ApiResponse(responseCode = "200", description = "사용할 수 있는 이메일")

--- a/src/main/java/com/pawland/auth/dto/request/NicknameDupCheckRequest.java
+++ b/src/main/java/com/pawland/auth/dto/request/NicknameDupCheckRequest.java
@@ -1,0 +1,18 @@
+package com.pawland.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NicknameDupCheckRequest {
+
+    @NotBlank(message = "닉네임을 입력해주세요.")
+    private String nickname;
+
+    public NicknameDupCheckRequest(String nickname) {
+        this.nickname = nickname;
+    }
+}

--- a/src/main/java/com/pawland/auth/dto/response/OAuthAttributes.java
+++ b/src/main/java/com/pawland/auth/dto/response/OAuthAttributes.java
@@ -12,7 +12,6 @@ import java.util.Map;
 @ToString
 public class OAuthAttributes {
 
-    private static final String TEMP_NICKNAME = "임시 닉네임";
     private String nickname;
     private String email;
     private String profileImage;
@@ -53,7 +52,7 @@ public class OAuthAttributes {
         Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
         Map<String, Object> profile = (Map<String, Object>) account.get("profile");
         return OAuthAttributes.builder()
-            .nickname(TEMP_NICKNAME)
+            .nickname((String) attributes.get("temp_nickname"))
             .email(account.get("email") + "/" + providerName)
             .profileImage((String) profile.get("profile_image_url"))
             .provider(providerName)
@@ -62,7 +61,7 @@ public class OAuthAttributes {
 
     private static OAuthAttributes ofGoogle(String providerName, Map<String, Object> attributes) {
         return OAuthAttributes.builder()
-            .nickname(TEMP_NICKNAME)
+            .nickname((String) attributes.get("temp_nickname"))
             .email(attributes.get("email") + "/" + providerName)
             .profileImage((String) attributes.get("picture"))
             .provider(providerName)
@@ -72,7 +71,7 @@ public class OAuthAttributes {
     private static OAuthAttributes ofNaver(String providerName, Map<String, Object> attributes) {
         Map<String, Object> response = (Map<String, Object>) attributes.get("response");
         return OAuthAttributes.builder()
-            .nickname(TEMP_NICKNAME)
+            .nickname((String) attributes.get("temp_nickname"))
             .email(response.get("email") + "/" + providerName)
             .profileImage((String) response.get("profile_image"))
             .provider(providerName)

--- a/src/main/java/com/pawland/auth/facade/AuthFacade.java
+++ b/src/main/java/com/pawland/auth/facade/AuthFacade.java
@@ -25,6 +25,10 @@ public class AuthFacade {
     private final JwtUtils jwtUtils;
     private final AuthService authService;
 
+    public void checkNicknameDuplicate(String nickname) {
+        userService.checkNicknameDuplicate(nickname);
+    }
+
     public void checkEmailDuplicate(String email) {
         userService.checkEmailDuplicate(email);
     }

--- a/src/main/java/com/pawland/user/repository/UserRepository.java
+++ b/src/main/java/com/pawland/user/repository/UserRepository.java
@@ -10,4 +10,6 @@ import java.util.Optional;
 public interface UserRepository extends CrudRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
+
+    Optional<User> findByNickname(String nickname);
 }

--- a/src/main/java/com/pawland/user/service/UserService.java
+++ b/src/main/java/com/pawland/user/service/UserService.java
@@ -22,6 +22,13 @@ public class UserService {
 
     private final UserRepository userRepository;
 
+    public void checkNicknameDuplicate(String nickname) {
+        Optional<User> foundUser = userRepository.findByNickname(nickname);
+        if (foundUser.isPresent()) {
+            throw new AlreadyExistsUserException();
+        }
+    }
+
     public void checkEmailDuplicate(String email) {
         Optional<User> foundUser = userRepository.findByEmail(email);
         if (foundUser.isPresent()) {
@@ -31,6 +38,7 @@ public class UserService {
 
     @Transactional
     public void register(User user) {
+        checkNicknameDuplicate(user.getNickname());
         checkEmailDuplicate(user.getEmail());
         userRepository.save(user);
     }

--- a/src/test/java/com/pawland/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/pawland/auth/controller/AuthControllerTest.java
@@ -578,7 +578,9 @@ class AuthControllerTest {
                 .thenReturn(oauth2User);
 
             // expected
-            mockMvc.perform(get("/api/auth/oauth2/" + provider + "?code=" + code))
+            mockMvc.perform(get("/api/auth/oauth2/{provider}", provider)
+                    .param("code", code)
+                )
                 .andDo(print())
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.message").value("소셜 로그인에 성공했습니다."))
@@ -596,7 +598,9 @@ class AuthControllerTest {
                 .thenThrow(new IllegalArgumentException("허용되지 않은 접근입니다."));
 
             // expected
-            mockMvc.perform(get("/api/auth/oauth2/" + provider + "?code=" + code))
+            mockMvc.perform(get("/api/auth/oauth2/{provider}", provider)
+                    .param("code", code)
+                )
                 .andDo(print())
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("허용되지 않은 접근입니다."))

--- a/src/test/java/com/pawland/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/pawland/auth/controller/AuthControllerTest.java
@@ -1,10 +1,7 @@
 package com.pawland.auth.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.pawland.auth.dto.request.SendVerificationCodeRequest;
-import com.pawland.auth.dto.request.EmailDupCheckRequest;
-import com.pawland.auth.dto.request.SignupRequest;
-import com.pawland.auth.dto.request.VerifyCodeRequest;
+import com.pawland.auth.dto.request.*;
 import com.pawland.auth.dto.response.OAuthAttributes;
 import com.pawland.auth.service.AuthService;
 import com.pawland.global.config.security.domain.LoginRequest;
@@ -73,7 +70,52 @@ class AuthControllerTest {
         });
     }
 
-    @DisplayName("이메일로 중복 확인 요청 시")
+    @DisplayName("닉네임 중복 확인 요청 시")
+    @Nested
+    class nicknameDupCheck {
+        @DisplayName("가입되지 않은 닉네임으로 중복 확인 시 성공 메시지를 반환한다.")
+        @Test
+        void emailDupCheck1() throws Exception {
+            // given
+            NicknameDupCheckRequest request = new NicknameDupCheckRequest("나는짱");
+            String json = objectMapper.writeValueAsString(request);
+
+            // expected
+            mockMvc.perform(post("/api/auth/nickname-dupcheck")
+                    .contentType(APPLICATION_JSON)
+                    .content(json)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("사용할 수 있는 닉네임입니다."));
+        }
+
+        @DisplayName("이미 가입된 닉네임으로 중복 확인 시 오류 메시지를 반환한다.")
+        @Test
+        void emailDupCheck2() throws Exception {
+            // given
+            User user = User.builder()
+                .email("midcon@nav.com")
+                .password("asd123123")
+                .nickname("나는짱")
+                .build();
+            userRepository.save(user);
+
+            NicknameDupCheckRequest request = new NicknameDupCheckRequest("나는짱");
+            String json = objectMapper.writeValueAsString(request);
+
+            // expected
+            mockMvc.perform(post("/api/auth/nickname-dupcheck")
+                    .contentType(APPLICATION_JSON)
+                    .content(json)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("이미 존재하는 유저입니다."));
+        }
+    }
+
+    @DisplayName("이메일 중복 확인 요청 시")
     @Nested
     class emailDupCheck {
         @DisplayName("가입되지 않은 이메일로 중복 확인 시 성공 메시지를 반환한다.")

--- a/src/test/java/com/pawland/user/service/UserServiceTest.java
+++ b/src/test/java/com/pawland/user/service/UserServiceTest.java
@@ -32,32 +32,68 @@ class UserServiceTest {
         userRepository.deleteAll();
     }
 
-    @DisplayName("이메일 중복 확인 시 중복된 이메일이 없으면 성공한다.")
-    @Test
-    void checkEmailDuplicate1() {
-        // given
-        String email = "midcon@nav.com";
+    @DisplayName("이메일 중복 확인 시")
+    @Nested
+    class checkNicknameDuplicate {
+        @DisplayName("중복된 이메일이 없으면 성공한다.")
+        @Test
+        void checkNicknameDuplicate1() {
+            // given
+            String nickname = "나는짱";
 
-        // expected
-        assertThatCode(() -> userService.checkEmailDuplicate(email))
-            .doesNotThrowAnyException();
+            // expected
+            assertThatCode(() -> userService.checkNicknameDuplicate(nickname))
+                .doesNotThrowAnyException();
+        }
+
+        @DisplayName("중복된 이메일이 있으면 실패한다.")
+        @Test
+        void checkNicknameDuplicate2() {
+            // given
+            User user = User.builder()
+                .email("mid@nav.com")
+                .password("asd123123")
+                .nickname("나는짱")
+                .build();
+            userRepository.save(user);
+
+            // expected
+            assertThatThrownBy(() -> userService.checkNicknameDuplicate("나는짱"))
+                .isInstanceOf(AlreadyExistsUserException.class)
+                .hasMessageContaining("이미 존재하는 유저입니다.");
+        }
     }
 
-    @DisplayName("이메일 중복 확인 시 중복된 이메일이 있으면 실패한다.")
-    @Test
-    void checkEmailDuplicate2() {
-        // given
-        User user = User.builder()
-            .email("mid@nav.com")
-            .password("asd123123")
-            .nickname("나는짱")
-            .build();
-        userRepository.save(user);
+    @DisplayName("이메일 중복 확인 시")
+    @Nested
+    class checkEmailDuplicate {
+        @DisplayName("중복된 이메일이 없으면 성공한다.")
+        @Test
+        void checkEmailDuplicate1() {
+            // given
+            String email = "midcon@nav.com";
 
-        // expected
-        assertThatThrownBy(() -> userService.checkEmailDuplicate("mid@nav.com"))
-            .isInstanceOf(AlreadyExistsUserException.class)
-            .hasMessageContaining("이미 존재하는 유저입니다.");
+            // expected
+            assertThatCode(() -> userService.checkEmailDuplicate(email))
+                .doesNotThrowAnyException();
+        }
+
+        @DisplayName("중복된 이메일이 있으면 실패한다.")
+        @Test
+        void checkEmailDuplicate2() {
+            // given
+            User user = User.builder()
+                .email("mid@nav.com")
+                .password("asd123123")
+                .nickname("나는짱")
+                .build();
+            userRepository.save(user);
+
+            // expected
+            assertThatThrownBy(() -> userService.checkEmailDuplicate("mid@nav.com"))
+                .isInstanceOf(AlreadyExistsUserException.class)
+                .hasMessageContaining("이미 존재하는 유저입니다.");
+        }
     }
 
     @DisplayName("유저 등록 시")
@@ -102,6 +138,29 @@ class UserServiceTest {
 
             // expected
             assertThatThrownBy(() -> userService.register(duplicateEmailUser))
+                .isInstanceOf(AlreadyExistsUserException.class)
+                .hasMessageContaining("이미 존재하는 유저입니다.");
+        }
+
+        @DisplayName("정상적인 정보 입력 시 중복 닉네임이 존재하면 실패한다.")
+        @Test
+        void register3() {
+            // given
+            User user = User.builder()
+                .email("mid@naver.com")
+                .password("asd123123")
+                .nickname("나는짱")
+                .build();
+            userService.register(user);
+
+            User duplicateNicknameUser = User.builder()
+                .email("mid1@naver.com")
+                .password("asd123123")
+                .nickname("나는짱")
+                .build();
+
+            // expected
+            assertThatThrownBy(() -> userService.register(duplicateNicknameUser))
                 .isInstanceOf(AlreadyExistsUserException.class)
                 .hasMessageContaining("이미 존재하는 유저입니다.");
         }


### PR DESCRIPTION
## 🛠️주요 변경 사항
- 닉네임 중복 확인 기능을 추가했습니다.
- 일반 회원가입 시 회원 정보 저장 전에 중복 확인합니다.
- 소셜 로그인으로 회원가입 시 닉네임이 중복되지 않게 랜덤 닉네임으로 저장 합니다.

## ❗관련이슈
- #23 