### PR TITLE
refactor: 메일 인증 기능 리팩토링

### DIFF
--- a/src/main/java/com/pawland/global/config/RedisConfig.java
+++ b/src/main/java/com/pawland/global/config/RedisConfig.java
@@ -13,7 +13,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @Slf4j
 @EnableRedisRepositories
 @RequiredArgsConstructor
-@ConfigurationProperties(prefix = "spring.redis")
+@ConfigurationProperties(prefix = "spring.data.redis")
 public class RedisConfig {
 
     private final String host;
@@ -34,5 +34,4 @@ public class RedisConfig {
         redisTemplate.setValueSerializer(new StringRedisSerializer());
         return redisTemplate;
     }
-
 }

--- a/src/main/java/com/pawland/mail/repository/MailRepository.java
+++ b/src/main/java/com/pawland/mail/repository/MailRepository.java
@@ -10,7 +10,7 @@ import java.time.Duration;
 
 @Repository
 @RequiredArgsConstructor
-public class VerifyCodeRepository {
+public class MailRepository {
 
     private final RedisTemplate<String, String> redisTemplate;
 

--- a/src/main/java/com/pawland/mail/repository/VerifyCodeRepository.java
+++ b/src/main/java/com/pawland/mail/repository/VerifyCodeRepository.java
@@ -1,0 +1,33 @@
+package com.pawland.mail.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+
+@Repository
+@RequiredArgsConstructor
+public class VerifyCodeRepository {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void save(String key, String value, Duration duration) {
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+        values.set(key, value, duration);
+    }
+
+    public String findByEmail(String email){
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+        return values.get(email);
+    }
+
+    public void deleteAll() {
+        redisTemplate.execute((RedisCallback<Object>) connection -> {
+            connection.serverCommands().flushDb();
+            return null;
+        });
+    }
+}

--- a/src/test/java/com/pawland/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/pawland/auth/controller/AuthControllerTest.java
@@ -6,7 +6,7 @@ import com.pawland.auth.dto.response.OAuthAttributes;
 import com.pawland.auth.service.AuthService;
 import com.pawland.global.config.security.domain.LoginRequest;
 import com.pawland.global.domain.DefaultImage;
-import com.pawland.mail.repository.VerifyCodeRepository;
+import com.pawland.mail.repository.MailRepository;
 import com.pawland.user.domain.LoginType;
 import com.pawland.user.domain.User;
 import com.pawland.user.repository.UserRepository;
@@ -57,12 +57,12 @@ class AuthControllerTest {
     private AuthService authService;
 
     @Autowired
-    private VerifyCodeRepository verifyCodeRepository;
+    private MailRepository mailRepository;
 
     @AfterEach
     void tearDown() {
         userRepository.deleteAll();
-        verifyCodeRepository.deleteAll();
+        mailRepository.deleteAll();
     }
 
     @DisplayName("닉네임 중복 확인 요청 시")
@@ -215,7 +215,7 @@ class AuthControllerTest {
             // given
             String email = "test@example.com";
             String verificationCode = "123456";
-            verifyCodeRepository.save(email, verificationCode, Duration.ofMinutes(3));
+            mailRepository.save(email, verificationCode, Duration.ofMinutes(3));
 
             VerifyCodeRequest request = VerifyCodeRequest.builder()
                 .email(email)
@@ -242,7 +242,7 @@ class AuthControllerTest {
             String email = "test@example.com";
             String verificationCode = "123456";
             String WrongCode = "111111";
-            verifyCodeRepository.save(email, verificationCode, Duration.ofMinutes(3));
+            mailRepository.save(email, verificationCode, Duration.ofMinutes(3));
 
             VerifyCodeRequest request = VerifyCodeRequest.builder()
                 .email(email)
@@ -269,7 +269,7 @@ class AuthControllerTest {
             String email = "test@example.com";
             String notRequestedEmail = "midcon@nav.com";
             String verificationCode = "123456";
-            verifyCodeRepository.save(email, verificationCode, Duration.ofMinutes(3));
+            mailRepository.save(email, verificationCode, Duration.ofMinutes(3));
 
             VerifyCodeRequest request = VerifyCodeRequest.builder()
                 .email(notRequestedEmail)
@@ -349,7 +349,7 @@ class AuthControllerTest {
                     .password("1234")
                     .nickname("나는짱")
                     .build();
-                verifyCodeRepository.save("midcon@nav.com", "ok", Duration.ofMinutes(5));
+                mailRepository.save("midcon@nav.com", "ok", Duration.ofMinutes(5));
 
                 String json = objectMapper.writeValueAsString(request);
 
@@ -374,7 +374,7 @@ class AuthControllerTest {
                     .nickname("나는짱")
                     .build();
                 userRepository.save(user);
-                verifyCodeRepository.save("midcon@nav.com", "ok",Duration.ofMinutes(5));
+                mailRepository.save("midcon@nav.com", "ok",Duration.ofMinutes(5));
 
                 SignupRequest request = SignupRequest.builder()
                     .email("midcon@nav.com")

--- a/src/test/java/com/pawland/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/pawland/auth/controller/AuthControllerTest.java
@@ -6,6 +6,7 @@ import com.pawland.auth.dto.response.OAuthAttributes;
 import com.pawland.auth.service.AuthService;
 import com.pawland.global.config.security.domain.LoginRequest;
 import com.pawland.global.domain.DefaultImage;
+import com.pawland.mail.repository.VerifyCodeRepository;
 import com.pawland.user.domain.LoginType;
 import com.pawland.user.domain.User;
 import com.pawland.user.repository.UserRepository;
@@ -17,9 +18,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.redis.core.RedisCallback;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.http.MediaType;
 import org.springframework.mail.MailAuthenticationException;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -59,15 +57,12 @@ class AuthControllerTest {
     private AuthService authService;
 
     @Autowired
-    private RedisTemplate<String, String> redisTemplate;
+    private VerifyCodeRepository verifyCodeRepository;
 
     @AfterEach
     void tearDown() {
         userRepository.deleteAll();
-        redisTemplate.execute((RedisCallback<Object>) connection -> {
-            connection.serverCommands().flushDb();
-            return null;
-        });
+        verifyCodeRepository.deleteAll();
     }
 
     @DisplayName("닉네임 중복 확인 요청 시")
@@ -220,8 +215,7 @@ class AuthControllerTest {
             // given
             String email = "test@example.com";
             String verificationCode = "123456";
-            ValueOperations<String, String> values = redisTemplate.opsForValue();
-            values.set(email, verificationCode, Duration.ofMinutes(3));
+            verifyCodeRepository.save(email, verificationCode, Duration.ofMinutes(3));
 
             VerifyCodeRequest request = VerifyCodeRequest.builder()
                 .email(email)
@@ -248,8 +242,7 @@ class AuthControllerTest {
             String email = "test@example.com";
             String verificationCode = "123456";
             String WrongCode = "111111";
-            ValueOperations<String, String> values = redisTemplate.opsForValue();
-            values.set(email, verificationCode, Duration.ofMinutes(3));
+            verifyCodeRepository.save(email, verificationCode, Duration.ofMinutes(3));
 
             VerifyCodeRequest request = VerifyCodeRequest.builder()
                 .email(email)
@@ -276,8 +269,7 @@ class AuthControllerTest {
             String email = "test@example.com";
             String notRequestedEmail = "midcon@nav.com";
             String verificationCode = "123456";
-            ValueOperations<String, String> values = redisTemplate.opsForValue();
-            values.set(email, verificationCode, Duration.ofMinutes(3));
+            verifyCodeRepository.save(email, verificationCode, Duration.ofMinutes(3));
 
             VerifyCodeRequest request = VerifyCodeRequest.builder()
                 .email(notRequestedEmail)
@@ -357,8 +349,7 @@ class AuthControllerTest {
                     .password("1234")
                     .nickname("나는짱")
                     .build();
-                ValueOperations<String, String> values = redisTemplate.opsForValue();
-                values.set("midcon@nav.com", "ok");
+                verifyCodeRepository.save("midcon@nav.com", "ok", Duration.ofMinutes(5));
 
                 String json = objectMapper.writeValueAsString(request);
 
@@ -383,8 +374,7 @@ class AuthControllerTest {
                     .nickname("나는짱")
                     .build();
                 userRepository.save(user);
-                ValueOperations<String, String> values = redisTemplate.opsForValue();
-                values.set("midcon@nav.com", "ok");
+                verifyCodeRepository.save("midcon@nav.com", "ok",Duration.ofMinutes(5));
 
                 SignupRequest request = SignupRequest.builder()
                     .email("midcon@nav.com")

--- a/src/test/java/com/pawland/mail/service/MailVerificationServiceTest.java
+++ b/src/test/java/com/pawland/mail/service/MailVerificationServiceTest.java
@@ -3,13 +3,14 @@ package com.pawland.mail.service;
 import com.pawland.global.config.MailConfig;
 import com.pawland.global.exception.InvalidCodeException;
 import com.pawland.global.exception.InvalidUserException;
-import com.pawland.mail.repository.VerifyCodeRepository;
+import com.pawland.mail.repository.MailRepository;
 import jakarta.mail.MessagingException;
 import jakarta.mail.Session;
 import jakarta.mail.internet.MimeMessage;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -37,17 +38,13 @@ class MailVerificationServiceTest {
     private MailVerificationService mailVerificationService;
 
     @Autowired
-    private VerifyCodeRepository verifyCodeRepository;
+    private MailRepository mailRepository;
 
+    @Mock
+    private MailRepository mockMailRepository;
+
+    @InjectMocks
     private MailVerificationService mockMailService;
-
-    private VerifyCodeRepository mockVerifyCodeRepository;
-
-    @BeforeEach
-    void setUp() {
-        mockVerifyCodeRepository = mock(VerifyCodeRepository.class);
-        mockMailService = new MailVerificationService(mailConfig, mailSender, mockVerifyCodeRepository);
-    }
 
     @DisplayName("이메일 전송 성공 Mock 테스트")
     @Test
@@ -92,7 +89,7 @@ class MailVerificationServiceTest {
 
         // when
         mailVerificationService.sendVerificationCode(toEmail);
-        String result = verifyCodeRepository.findByEmail(toEmail);
+        String result = mailRepository.findByEmail(toEmail);
 
         // then
         assertThat(result).isNotNull();
@@ -105,11 +102,11 @@ class MailVerificationServiceTest {
         // given
         String email = "test@example.com";
         String verificationCode = "123456";
-        verifyCodeRepository.save(email, verificationCode, Duration.ofMinutes(3));
+        mailRepository.save(email, verificationCode, Duration.ofMinutes(3));
 
         // when
         mailVerificationService.verifyCode(email, verificationCode);
-        String result = verifyCodeRepository.findByEmail(email);
+        String result = mailRepository.findByEmail(email);
 
         // then
         assertThat(result).isNotNull();
@@ -123,7 +120,7 @@ class MailVerificationServiceTest {
         String email = "test@example.com";
         String verificationCode = "123456";
         String WrongCode = "111111";
-        verifyCodeRepository.save(email, verificationCode, Duration.ofMinutes(3));
+        mailRepository.save(email, verificationCode, Duration.ofMinutes(3));
 
         // expected
         assertThatThrownBy(() -> mailVerificationService.verifyCode(email, WrongCode))
@@ -138,7 +135,7 @@ class MailVerificationServiceTest {
         String email = "test@example.com";
         String notRequestedEmail = "midcon@nav.com";
         String verificationCode = "123456";
-        verifyCodeRepository.save(email, verificationCode, Duration.ofMinutes(3));
+        mailRepository.save(email, verificationCode, Duration.ofMinutes(3));
 
         // expected
         assertThatThrownBy(() -> mailVerificationService.verifyCode(notRequestedEmail, verificationCode))
@@ -152,14 +149,14 @@ class MailVerificationServiceTest {
         // given
         String verifiedEmail = "test@example.com";
         String authSuccessStatus = "ok";
-        when(mockVerifyCodeRepository.findByEmail(verifiedEmail)).thenReturn(authSuccessStatus);
+        when(mockMailRepository.findByEmail(verifiedEmail)).thenReturn(authSuccessStatus);
 
         // when
         mockMailService.checkEmailVerification(verifiedEmail);
 
         // then
-        verify(mockVerifyCodeRepository).findByEmail(verifiedEmail);
-        verify(mockVerifyCodeRepository, times(1)).findByEmail(verifiedEmail);
+        verify(mockMailRepository).findByEmail(verifiedEmail);
+        verify(mockMailRepository, times(1)).findByEmail(verifiedEmail);
     }
 
     @DisplayName("이메일을 인증하지 않은 유저가 회원가입 요청 시 실패한다.")
@@ -168,7 +165,7 @@ class MailVerificationServiceTest {
         // given
         String authWaitingEmail = "test@example.com";
         String authWaitingStatus = "123456";
-        when(mockVerifyCodeRepository.findByEmail(authWaitingEmail)).thenReturn(authWaitingStatus);
+        when(mockMailRepository.findByEmail(authWaitingEmail)).thenReturn(authWaitingStatus);
 
         // expected
         assertThatThrownBy(() ->  mockMailService.checkEmailVerification(authWaitingEmail))
@@ -182,7 +179,7 @@ class MailVerificationServiceTest {
         // given
         String authNotProcessingEmail = "test@example.com";
         String authNotProcessingStatus = null;
-        when(mockVerifyCodeRepository.findByEmail(authNotProcessingEmail)).thenReturn(authNotProcessingStatus);
+        when(mockMailRepository.findByEmail(authNotProcessingEmail)).thenReturn(authNotProcessingStatus);
 
         // expected
         assertThatThrownBy(() ->  mockMailService.checkEmailVerification(authNotProcessingEmail))


### PR DESCRIPTION
## 🛠️주요 변경 사항
- 메일 인증 번호를 저장하는 레디스 관련 설정을 변경했습니다.
- yml에서 중복되는 부분을 줄이기 위해 RedisConfig의 @ConfigurationProperties의 prefix를 수정했습니다.
- 레디스를 이용한 저장, 조회, 수정 로직을 Repository로 추상화 했습니다.

## ❗관련이슈
- closed: #8 