### PR TITLE
feat: 채팅방 생성 / 내 채팅방 조회 기능 구현

### DIFF
--- a/src/main/java/com/pawland/chat/controller/ChatController.java
+++ b/src/main/java/com/pawland/chat/controller/ChatController.java
@@ -1,0 +1,38 @@
+package com.pawland.chat.controller;
+
+import com.pawland.chat.dto.request.ChatRoomCreateRequest;
+import com.pawland.chat.service.ChatService;
+import com.pawland.global.config.security.domain.UserPrincipal;
+import com.pawland.global.dto.ApiMessageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import static org.springframework.http.HttpStatus.CREATED;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/chat")
+@RequiredArgsConstructor
+public class ChatController {
+
+    private final ChatService chatService;
+
+    @Operation(summary = "채팅방 생성", description = "채팅방을 생성합니다.(미완성)")
+    @ApiResponse(responseCode = "201", description = "채팅방 생성 성공")
+    @ApiResponse(responseCode = "400", description = "잘못된 상품 아이디 유저 아이디")
+    @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    @PostMapping("/rooms")
+    public ResponseEntity<ApiMessageResponse> createChatRoom(@AuthenticationPrincipal UserPrincipal userPrincipal,
+                                                             @Valid @RequestBody ChatRoomCreateRequest request) {
+        chatService.createChatRoom(userPrincipal.getUserId(), request);
+        return ResponseEntity
+            .status(CREATED)
+            .body(new ApiMessageResponse("채팅방 생성 완료"));
+    }
+}

--- a/src/main/java/com/pawland/chat/controller/ChatController.java
+++ b/src/main/java/com/pawland/chat/controller/ChatController.java
@@ -9,7 +9,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -19,7 +18,6 @@ import java.util.List;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.OK;
 
-@Slf4j
 @RestController
 @RequestMapping("/api/chat")
 @RequiredArgsConstructor
@@ -29,6 +27,7 @@ public class ChatController {
 
     @Operation(summary = "내 채팅 목록 조회", description = "내 채팅 목록을 반환합니다.(미완성)")
     @ApiResponse(responseCode = "200", description = "채팅 목록 조회 성공")
+    @ApiResponse(responseCode = "500", description = "서버 내부 오류")
     @GetMapping("/rooms")
     public ResponseEntity<List<ChatRoomInfoResponse>> getChatRoomList(@AuthenticationPrincipal UserPrincipal userPrincipal) {
         List<ChatRoomInfoResponse> chatRoomList = chatService.getChatRoomList(userPrincipal.getUserId());
@@ -37,7 +36,7 @@ public class ChatController {
             .body(chatRoomList);
     }
 
-    @Operation(summary = "채팅방 생성", description = "채팅방을 생성합니다.(미완성)")
+    @Operation(summary = "채팅방 생성", description = "채팅방을 생성합니다.")
     @ApiResponse(responseCode = "201", description = "채팅방 생성 성공")
     @ApiResponse(responseCode = "400", description = "잘못된 상품 아이디 유저 아이디")
     @ApiResponse(responseCode = "500", description = "서버 내부 오류")

--- a/src/main/java/com/pawland/chat/controller/ChatController.java
+++ b/src/main/java/com/pawland/chat/controller/ChatController.java
@@ -1,6 +1,7 @@
 package com.pawland.chat.controller;
 
 import com.pawland.chat.dto.request.ChatRoomCreateRequest;
+import com.pawland.chat.dto.response.ChatRoomInfoResponse;
 import com.pawland.chat.service.ChatService;
 import com.pawland.global.config.security.domain.UserPrincipal;
 import com.pawland.global.dto.ApiMessageResponse;
@@ -13,7 +14,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.OK;
 
 @Slf4j
 @RestController
@@ -22,6 +26,16 @@ import static org.springframework.http.HttpStatus.CREATED;
 public class ChatController {
 
     private final ChatService chatService;
+
+    @Operation(summary = "내 채팅 목록 조회", description = "내 채팅 목록을 반환합니다.(미완성)")
+    @ApiResponse(responseCode = "200", description = "채팅 목록 조회 성공")
+    @GetMapping("/rooms")
+    public ResponseEntity<List<ChatRoomInfoResponse>> getChatRoomList(@AuthenticationPrincipal UserPrincipal userPrincipal) {
+        List<ChatRoomInfoResponse> chatRoomList = chatService.getChatRoomList(userPrincipal.getUserId());
+        return ResponseEntity
+            .status(OK)
+            .body(chatRoomList);
+    }
 
     @Operation(summary = "채팅방 생성", description = "채팅방을 생성합니다.(미완성)")
     @ApiResponse(responseCode = "201", description = "채팅방 생성 성공")

--- a/src/main/java/com/pawland/chat/domain/ChatRoom.java
+++ b/src/main/java/com/pawland/chat/domain/ChatRoom.java
@@ -1,0 +1,39 @@
+package com.pawland.chat.domain;
+
+import com.pawland.global.domain.BaseTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoom extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    private Long buyerId;
+
+    @NotNull
+    private Long sellerId;
+
+    @NotNull
+    private Long productId;
+
+    @Builder
+    public ChatRoom(Long id, Long sellerId, Long buyerId, Long productId) {
+        this.id = id;
+        this.sellerId = sellerId;
+        this.buyerId = buyerId;
+        this.productId = productId;
+    }
+}

--- a/src/main/java/com/pawland/chat/dto/request/ChatRoomCreateRequest.java
+++ b/src/main/java/com/pawland/chat/dto/request/ChatRoomCreateRequest.java
@@ -1,0 +1,33 @@
+package com.pawland.chat.dto.request;
+
+import com.pawland.chat.domain.ChatRoom;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoomCreateRequest {
+
+    @NotNull
+    private Long sellerId;
+
+    @NotNull
+    private Long productId;
+
+    @Builder
+    public ChatRoomCreateRequest(Long sellerId, Long productId) {
+        this.sellerId = sellerId;
+        this.productId = productId;
+    }
+
+    public ChatRoom toChatRoomWithMyId(Long buyerId) {
+        return ChatRoom.builder()
+            .buyerId(buyerId)
+            .sellerId(sellerId)
+            .productId(productId)
+            .build();
+    }
+}

--- a/src/main/java/com/pawland/chat/dto/request/ChatRoomCreateRequest.java
+++ b/src/main/java/com/pawland/chat/dto/request/ChatRoomCreateRequest.java
@@ -1,6 +1,7 @@
 package com.pawland.chat.dto.request;
 
 import com.pawland.chat.domain.ChatRoom;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -9,6 +10,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Schema(name = "채팅방 생성 요청")
 public class ChatRoomCreateRequest {
 
     @NotNull

--- a/src/main/java/com/pawland/chat/dto/response/ChatRoomInfoResponse.java
+++ b/src/main/java/com/pawland/chat/dto/response/ChatRoomInfoResponse.java
@@ -1,9 +1,11 @@
 package com.pawland.chat.dto.response;
 
 import com.pawland.product.domain.Status;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 @Getter
+@Schema(name = "채팅방 목록 조회 시 개별 채팅방 정보")
 public class ChatRoomInfoResponse {
 
     private Long roomId;
@@ -17,6 +19,7 @@ public class ChatRoomInfoResponse {
     }
 
     @Getter
+    @Schema(name = "채팅 상대의 유저 정보")
     public static class UserInfo {
         private Long id;
         private String nickname;
@@ -30,6 +33,7 @@ public class ChatRoomInfoResponse {
     }
 
     @Getter
+    @Schema(name = "채팅방의 상품 정보")
     public static class ProductInfo {
         private Long id;
         private int price;

--- a/src/main/java/com/pawland/chat/dto/response/ChatRoomInfoResponse.java
+++ b/src/main/java/com/pawland/chat/dto/response/ChatRoomInfoResponse.java
@@ -1,0 +1,51 @@
+package com.pawland.chat.dto.response;
+
+import com.pawland.product.domain.Status;
+import lombok.*;
+
+@Getter
+public class ChatRoomInfoResponse {
+
+    private Long roomId;
+    private UserInfo opponentUser;
+    private ProductInfo productInfo;
+
+    public ChatRoomInfoResponse(Long roomId, UserInfo opponentUser, ProductInfo productInfo) {
+        this.roomId = roomId;
+        this.opponentUser = opponentUser;
+        this.productInfo = productInfo;
+    }
+
+    @Getter
+    public static class UserInfo {
+        private Long id;
+        private String nickname;
+        private String profileImage;
+
+        public UserInfo(Long id, String nickname, String profileImage) {
+            this.id = id;
+            this.nickname = nickname;
+            this.profileImage = profileImage;
+        }
+    }
+
+    @Getter
+    public static class ProductInfo {
+        private Long id;
+        private int price;
+        private String productName;
+        private String imageThumbnail;
+        private Status saleState;
+        private Long purchaser;
+
+        public ProductInfo(Long id, int price, String productName,
+                           String imageThumbnail, Status saleState, Long purchaser) {
+            this.id = id;
+            this.price = price;
+            this.productName = productName;
+            this.imageThumbnail = imageThumbnail;
+            this.saleState = saleState;
+            this.purchaser = purchaser;
+        }
+    }
+}

--- a/src/main/java/com/pawland/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/pawland/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,8 @@
+package com.pawland.chat.repository;
+
+import com.pawland.chat.domain.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
+}

--- a/src/main/java/com/pawland/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/pawland/chat/repository/ChatRoomRepository.java
@@ -3,6 +3,6 @@ package com.pawland.chat.repository;
 import com.pawland.chat.domain.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long>, ChatRoomRepositoryCustom {
 
 }

--- a/src/main/java/com/pawland/chat/repository/ChatRoomRepositoryCustom.java
+++ b/src/main/java/com/pawland/chat/repository/ChatRoomRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.pawland.chat.repository;
+
+import com.pawland.chat.dto.response.ChatRoomInfoResponse;
+
+import java.util.List;
+
+public interface ChatRoomRepositoryCustom {
+
+    List<ChatRoomInfoResponse> getMyChatRoomList(Long userId);
+}

--- a/src/main/java/com/pawland/chat/repository/ChatRoomRepositoryImpl.java
+++ b/src/main/java/com/pawland/chat/repository/ChatRoomRepositoryImpl.java
@@ -1,0 +1,50 @@
+package com.pawland.chat.repository;
+
+import com.pawland.chat.dto.response.ChatRoomInfoResponse;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.pawland.chat.domain.QChatRoom.chatRoom;
+import static com.pawland.product.domain.QProduct.product;
+import static com.pawland.user.domain.QUser.user;
+
+@Repository
+@RequiredArgsConstructor
+public class ChatRoomRepositoryImpl implements ChatRoomRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<ChatRoomInfoResponse> getMyChatRoomList(Long userId) {
+        return jpaQueryFactory
+            .select(Projections.constructor(ChatRoomInfoResponse.class,
+                chatRoom.id.as("roomId"),
+                Projections.constructor(ChatRoomInfoResponse.UserInfo.class,
+                    user.id,
+                    user.nickname,
+                    user.profileImage),
+                Projections.constructor(ChatRoomInfoResponse.ProductInfo.class,
+                    product.id,
+                    product.price,
+                    product.name.as("productName"),
+                    product.thumbnailImageUrl.as("imageThumbnail"),
+                    product.status.as("saleState"),
+                    product.purchaserId.as("purchaser"))
+            ))
+            .from(chatRoom)
+            .join(user)
+            .on(user.id.eq(
+                new CaseBuilder()
+                    .when(chatRoom.sellerId.eq(userId)).then(chatRoom.buyerId)
+                    .otherwise(chatRoom.sellerId)
+            ))
+            .where(chatRoom.buyerId.eq(userId).or(chatRoom.sellerId.eq(userId)))
+            .join(product).on(product.id.eq(chatRoom.productId))
+            .fetch();
+    }
+}

--- a/src/main/java/com/pawland/chat/service/ChatService.java
+++ b/src/main/java/com/pawland/chat/service/ChatService.java
@@ -1,6 +1,7 @@
 package com.pawland.chat.service;
 
 import com.pawland.chat.dto.request.ChatRoomCreateRequest;
+import com.pawland.chat.dto.response.ChatRoomInfoResponse;
 import com.pawland.chat.repository.ChatRoomRepository;
 import com.pawland.product.exception.ProductException;
 import com.pawland.product.respository.ProductJpaRepository;
@@ -10,8 +11,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ChatService {
 
     private final ChatRoomRepository chatRoomRepository;
@@ -22,6 +26,10 @@ public class ChatService {
     public void createChatRoom(Long userId, ChatRoomCreateRequest request) {
         validateChatRoomCreateRequest(request);
         chatRoomRepository.save(request.toChatRoomWithMyId(userId));
+    }
+
+    public List<ChatRoomInfoResponse> getChatRoomList(Long userId) {
+        return chatRoomRepository.getMyChatRoomList(userId);
     }
 
     private void validateChatRoomCreateRequest(ChatRoomCreateRequest request) {

--- a/src/main/java/com/pawland/chat/service/ChatService.java
+++ b/src/main/java/com/pawland/chat/service/ChatService.java
@@ -1,0 +1,33 @@
+package com.pawland.chat.service;
+
+import com.pawland.chat.dto.request.ChatRoomCreateRequest;
+import com.pawland.chat.repository.ChatRoomRepository;
+import com.pawland.product.exception.ProductException;
+import com.pawland.product.respository.ProductJpaRepository;
+import com.pawland.user.exception.UserException;
+import com.pawland.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final UserRepository userRepository;
+    private final ProductJpaRepository productJpaRepository;
+
+    @Transactional
+    public void createChatRoom(Long userId, ChatRoomCreateRequest request) {
+        validateChatRoomCreateRequest(request);
+        chatRoomRepository.save(request.toChatRoomWithMyId(userId));
+    }
+
+    private void validateChatRoomCreateRequest(ChatRoomCreateRequest request) {
+        userRepository.findById(request.getSellerId())
+            .orElseThrow(UserException.NotFoundUser::new);
+        productJpaRepository.findById(request.getProductId())
+            .orElseThrow(ProductException.NotFoundProduct::new);
+    }
+}

--- a/src/main/java/com/pawland/order/domain/Order.java
+++ b/src/main/java/com/pawland/order/domain/Order.java
@@ -52,6 +52,7 @@ public class Order extends BaseTimeEntity {
     }
 
     public void setSellerCheck(boolean sellerCheck) {
+        this.product.confirmPurchase(seller.getId());
         this.sellerCheck = sellerCheck;
         if (sellerCheck && buyerCheck) {
             changeStatus(OrderStatus.DONE);
@@ -59,6 +60,7 @@ public class Order extends BaseTimeEntity {
     }
 
     public void setBuyerCheck(boolean buyerCheck) {
+        this.product.confirmPurchase(buyer.getId());
         this.buyerCheck = buyerCheck;
         if (sellerCheck && buyerCheck) {
             changeStatus(OrderStatus.DONE);

--- a/src/main/java/com/pawland/product/domain/Product.java
+++ b/src/main/java/com/pawland/product/domain/Product.java
@@ -55,6 +55,8 @@ public class Product extends BaseTimeEntity {
     @OneToMany(mappedBy = "product")
     private Set<WishProduct> wishProducts = new HashSet<>();
 
+    private Long purchaserId = null;
+
     @Builder
     public Product(String category,String species,String condition,String name, int price, String content, String region,User seller,String thumbnailImageUrl,List<String> imageUrls) {
         this.category = Category.getInstance(category);
@@ -105,4 +107,7 @@ public class Product extends BaseTimeEntity {
         wishProduct.setProduct(null);
     }
 
+    public void confirmPurchase(Long purchaserId) {
+        this.purchaserId = purchaserId;
+    }
 }

--- a/src/test/java/com/pawland/chat/controller/ChatControllerTest.java
+++ b/src/test/java/com/pawland/chat/controller/ChatControllerTest.java
@@ -1,6 +1,7 @@
 package com.pawland.chat.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pawland.chat.domain.ChatRoom;
 import com.pawland.chat.dto.request.ChatRoomCreateRequest;
 import com.pawland.chat.repository.ChatRoomRepository;
 import com.pawland.global.config.TestSecurityConfig;
@@ -64,20 +65,10 @@ class ChatControllerTest {
         @Test
         void createChatRoom1() throws Exception {
             // given
-            User seller = User.builder()
-                .nickname("판매자")
-                .email("midcon2@nav.com")
-                .password("asd123123")
-                .build();
+            User seller = createUser("판매자1", "midcon2@naver.com", "asd123123");
             userRepository.save(seller);
 
-            Product product = Product.builder()
-                .name("나는짱물건")
-                .price(10000)
-                .category("장난감")
-                .species("DOG")
-                .condition("NEW")
-                .build();
+            Product product = createProduct("나는짱물건", 10000, "장난감", "DOG", "NEW");
             productJpaRepository.save(product);
 
             ChatRoomCreateRequest request = ChatRoomCreateRequest.builder()
@@ -102,11 +93,7 @@ class ChatControllerTest {
         @Test
         void createChatRoom2() throws Exception {
             // given
-            User seller = User.builder()
-                .nickname("판매자")
-                .email("midcon2@nav.com")
-                .password("asd123123")
-                .build();
+            User seller = createUser("판매자1", "midcon2@naver.com", "asd123123");
             userRepository.save(seller);
 
             Long invalidProductId = 0L;
@@ -133,13 +120,7 @@ class ChatControllerTest {
         @Test
         void createChatRoom3() throws Exception {
             // given
-            Product product = Product.builder()
-                .name("나는짱물건")
-                .price(10000)
-                .category("장난감")
-                .species("DOG")
-                .condition("NEW")
-                .build();
+            Product product = createProduct("나는짱물건", 10000, "장난감", "DOG", "NEW");
             productJpaRepository.save(product);
 
             Long invalidSellerId = 0L;
@@ -160,5 +141,32 @@ class ChatControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value(USER_NOT_FOUND.getMessage()));
         }
+    }
+
+    private static User createUser(String nickname, String email, String password) {
+        return User.builder()
+            .nickname(nickname)
+            .email(email)
+            .password(password)
+            .build();
+    }
+
+    private Product createProduct(String name, int price, String category, String species, String condition) {
+        return Product.builder()
+            .name(name)
+            .price(price)
+            .category(category)
+            .species(species)
+            .condition(condition)
+            .build();
+    }
+
+    private static ChatRoom createChatRoom(Long buyerId, Long sellerId, Long productId) {
+        ChatRoom chatRoom = ChatRoom.builder()
+            .buyerId(buyerId)
+            .sellerId(sellerId)
+            .productId(productId)
+            .build();
+        return chatRoom;
     }
 }

--- a/src/test/java/com/pawland/chat/controller/ChatControllerTest.java
+++ b/src/test/java/com/pawland/chat/controller/ChatControllerTest.java
@@ -1,0 +1,164 @@
+package com.pawland.chat.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pawland.chat.dto.request.ChatRoomCreateRequest;
+import com.pawland.chat.repository.ChatRoomRepository;
+import com.pawland.global.config.TestSecurityConfig;
+import com.pawland.global.utils.PawLandMockUser;
+import com.pawland.product.domain.Product;
+import com.pawland.product.respository.ProductJpaRepository;
+import com.pawland.user.domain.User;
+import com.pawland.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static com.pawland.product.exception.ProductExceptionMessage.PRODUCT_NOT_FOUND;
+import static com.pawland.user.exception.UserExceptionMessage.USER_NOT_FOUND;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import(TestSecurityConfig.class)
+@ActiveProfiles("test")
+class ChatControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private ProductJpaRepository productJpaRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ChatRoomRepository chatRoomRepository;
+
+    @AfterEach
+    void tearDown() {
+        userRepository.deleteAll();
+        productJpaRepository.deleteAllInBatch();
+        chatRoomRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("채팅방 생성 시")
+    @Nested
+    class createChatRoom {
+        @DisplayName("유효한 요청이면 채팅방 생성에 성공한다.")
+        @PawLandMockUser
+        @Test
+        void createChatRoom1() throws Exception {
+            // given
+            User seller = User.builder()
+                .nickname("판매자")
+                .email("midcon2@nav.com")
+                .password("asd123123")
+                .build();
+            userRepository.save(seller);
+
+            Product product = Product.builder()
+                .name("나는짱물건")
+                .price(10000)
+                .category("장난감")
+                .species("DOG")
+                .condition("NEW")
+                .build();
+            productJpaRepository.save(product);
+
+            ChatRoomCreateRequest request = ChatRoomCreateRequest.builder()
+                .sellerId(seller.getId())
+                .productId(product.getId())
+                .build();
+
+            String json = objectMapper.writeValueAsString(request);
+
+            // expected
+            mockMvc.perform(post("/api/chat/rooms")
+                    .contentType(APPLICATION_JSON)
+                    .content(json)
+                )
+                .andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.message").value("채팅방 생성 완료"));
+        }
+
+        @DisplayName("요청한 상품 ID로 DB에서 상품 정보를 조회할 수 없으면 에러 메시지를 출력한다.")
+        @PawLandMockUser
+        @Test
+        void createChatRoom2() throws Exception {
+            // given
+            User seller = User.builder()
+                .nickname("판매자")
+                .email("midcon2@nav.com")
+                .password("asd123123")
+                .build();
+            userRepository.save(seller);
+
+            Long invalidProductId = 0L;
+
+            ChatRoomCreateRequest request = ChatRoomCreateRequest.builder()
+                .sellerId(seller.getId())
+                .productId(invalidProductId)
+                .build();
+
+            String json = objectMapper.writeValueAsString(request);
+
+            // expected
+            mockMvc.perform(post("/api/chat/rooms")
+                    .contentType(APPLICATION_JSON)
+                    .content(json)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(PRODUCT_NOT_FOUND.getMessage()));
+        }
+
+        @DisplayName("요청한 판매자 ID로 DB에서 판매자 정보를 조회할 수 없으면 에러 메시지를 출력한다.")
+        @PawLandMockUser
+        @Test
+        void createChatRoom3() throws Exception {
+            // given
+            Product product = Product.builder()
+                .name("나는짱물건")
+                .price(10000)
+                .category("장난감")
+                .species("DOG")
+                .condition("NEW")
+                .build();
+            productJpaRepository.save(product);
+
+            Long invalidSellerId = 0L;
+
+            ChatRoomCreateRequest request = ChatRoomCreateRequest.builder()
+                .sellerId(invalidSellerId)
+                .productId(product.getId())
+                .build();
+
+            String json = objectMapper.writeValueAsString(request);
+
+            // expected
+            mockMvc.perform(post("/api/chat/rooms")
+                    .contentType(APPLICATION_JSON)
+                    .content(json)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(USER_NOT_FOUND.getMessage()));
+        }
+    }
+}

--- a/src/test/java/com/pawland/chat/controller/ChatControllerTest.java
+++ b/src/test/java/com/pawland/chat/controller/ChatControllerTest.java
@@ -3,12 +3,14 @@ package com.pawland.chat.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pawland.chat.domain.ChatRoom;
 import com.pawland.chat.dto.request.ChatRoomCreateRequest;
+import com.pawland.chat.dto.response.ChatRoomInfoResponse;
 import com.pawland.chat.repository.ChatRoomRepository;
 import com.pawland.global.config.TestSecurityConfig;
 import com.pawland.global.utils.PawLandMockUser;
 import com.pawland.product.domain.Product;
 import com.pawland.product.respository.ProductJpaRepository;
 import com.pawland.user.domain.User;
+import com.pawland.user.exception.UserException;
 import com.pawland.user.repository.UserRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -21,9 +23,12 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.List;
+
 import static com.pawland.product.exception.ProductExceptionMessage.PRODUCT_NOT_FOUND;
 import static com.pawland.user.exception.UserExceptionMessage.USER_NOT_FOUND;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -140,6 +145,73 @@ class ChatControllerTest {
                 .andDo(print())
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value(USER_NOT_FOUND.getMessage()));
+        }
+    }
+
+    @DisplayName("내 채팅방 목록 조회 시")
+    @Nested
+    class getMyChatRoomList {
+        @DisplayName("내가 구매자인 채팅방과 판매자인 채팅방을 모두 조회한다.")
+        @PawLandMockUser
+        @Test
+        void getMyChatRoomList1() throws Exception {
+            // given
+            User seller1 = createUser("판매자1", "midcon2@naver.com", "asd123123");
+            User seller2 = createUser("판매자2", "midcon3@naver.com", "asd123123");
+            User buyer1 = createUser("구매자1", "midcon4@naver.com", "asd123123");
+            User buyer2 = createUser("구매자2", "midcon5@naver.com", "asd123123");
+            userRepository.saveAll(List.of(seller1, seller2, buyer1, buyer2));
+
+            User myAccount = userRepository.findByEmail("midcondria@naver.com")
+                .orElseThrow(UserException.NotFoundUser::new);
+
+            Product product1 = createProduct("나는짱물건1", 1000, "장난감", "DOG", "NEW");
+            Product product2 = createProduct("나는짱물건2", 2000, "장난감", "DOG", "NEW");
+            Product product3 = createProduct("나는짱물건3", 3000, "장난감", "DOG", "NEW");
+            Product product4 = createProduct("나는짱물건4", 4000, "장난감", "DOG", "NEW");
+            product3.confirmPurchase(1L);
+            productJpaRepository.saveAll(List.of(product1, product2, product3, product4));
+
+            ChatRoom myChatRoom1 = createChatRoom(myAccount.getId(), seller1.getId(), product1.getId());
+            ChatRoom myChatRoom2 = createChatRoom(myAccount.getId(), seller2.getId(), product2.getId());
+            ChatRoom myChatRoom3 = createChatRoom(buyer1.getId(), myAccount.getId(), product3.getId());
+            ChatRoom notMyChatRoom1 = createChatRoom(buyer1.getId(), seller2.getId(), product4.getId());
+            ChatRoom notMyChatRoom2 = createChatRoom(buyer2.getId(), seller2.getId(), product4.getId());
+            chatRoomRepository.saveAll(List.of(myChatRoom1, myChatRoom2, myChatRoom3, notMyChatRoom1, notMyChatRoom2));
+
+            // expected
+            mockMvc.perform(get("/api/chat/rooms"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(3));
+        }
+
+        @DisplayName("내가 참여하고 있는 채팅방이 없을 시 빈 리스트를 반환한다.")
+        @PawLandMockUser
+        @Test
+        void getMyChatRoomList2() throws Exception {
+            User seller1 = createUser("판매자1", "midcon2@naver.com", "asd123123");
+            User seller2 = createUser("판매자2", "midcon3@naver.com", "asd123123");
+            User buyer1 = createUser("구매자1", "midcon4@naver.com", "asd123123");
+            User buyer2 = createUser("구매자2", "midcon5@naver.com", "asd123123");
+            userRepository.saveAll(List.of(seller1, seller2, buyer1, buyer2));
+
+            User myAccount = userRepository.findByEmail("midcondria@naver.com")
+                .orElseThrow(UserException.NotFoundUser::new);
+
+            Product product1 = createProduct("나는짱물건1", 1000, "장난감", "DOG", "NEW");
+            Product product2 = createProduct("나는짱물건2", 2000, "장난감", "DOG", "NEW");
+            productJpaRepository.saveAll(List.of(product1, product2));
+
+            ChatRoom notMyChatRoom1 = createChatRoom(buyer1.getId(), seller1.getId(), product1.getId());
+            ChatRoom notMyChatRoom2 = createChatRoom(buyer2.getId(), seller2.getId(), product2.getId());
+            chatRoomRepository.saveAll(List.of(notMyChatRoom1, notMyChatRoom2));
+
+            // expected
+            mockMvc.perform(get("/api/chat/rooms"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isEmpty());
         }
     }
 

--- a/src/test/java/com/pawland/chat/controller/ChatControllerTest.java
+++ b/src/test/java/com/pawland/chat/controller/ChatControllerTest.java
@@ -73,7 +73,7 @@ class ChatControllerTest {
             User seller = createUser("판매자1", "midcon2@naver.com", "asd123123");
             userRepository.save(seller);
 
-            Product product = createProduct("나는짱물건", 10000, "장난감", "DOG", "NEW");
+            Product product = createProduct("나는짱물건", 10000, "장난감", "강아지", "새상품");
             productJpaRepository.save(product);
 
             ChatRoomCreateRequest request = ChatRoomCreateRequest.builder()
@@ -125,7 +125,7 @@ class ChatControllerTest {
         @Test
         void createChatRoom3() throws Exception {
             // given
-            Product product = createProduct("나는짱물건", 10000, "장난감", "DOG", "NEW");
+            Product product = createProduct("나는짱물건", 10000, "장난감", "강아지", "새상품");
             productJpaRepository.save(product);
 
             Long invalidSellerId = 0L;
@@ -165,10 +165,10 @@ class ChatControllerTest {
             User myAccount = userRepository.findByEmail("midcondria@naver.com")
                 .orElseThrow(UserException.NotFoundUser::new);
 
-            Product product1 = createProduct("나는짱물건1", 1000, "장난감", "DOG", "NEW");
-            Product product2 = createProduct("나는짱물건2", 2000, "장난감", "DOG", "NEW");
-            Product product3 = createProduct("나는짱물건3", 3000, "장난감", "DOG", "NEW");
-            Product product4 = createProduct("나는짱물건4", 4000, "장난감", "DOG", "NEW");
+            Product product1 = createProduct("나는짱물건1", 1000, "장난감", "강아지", "새상품");
+            Product product2 = createProduct("나는짱물건2", 2000, "장난감", "강아지", "새상품");
+            Product product3 = createProduct("나는짱물건3", 3000, "장난감", "강아지", "새상품");
+            Product product4 = createProduct("나는짱물건4", 4000, "장난감", "강아지", "새상품");
             product3.confirmPurchase(1L);
             productJpaRepository.saveAll(List.of(product1, product2, product3, product4));
 
@@ -199,8 +199,8 @@ class ChatControllerTest {
             User myAccount = userRepository.findByEmail("midcondria@naver.com")
                 .orElseThrow(UserException.NotFoundUser::new);
 
-            Product product1 = createProduct("나는짱물건1", 1000, "장난감", "DOG", "NEW");
-            Product product2 = createProduct("나는짱물건2", 2000, "장난감", "DOG", "NEW");
+            Product product1 = createProduct("나는짱물건1", 1000, "장난감", "강아지", "새상품");
+            Product product2 = createProduct("나는짱물건2", 2000, "장난감", "강아지", "새상품");
             productJpaRepository.saveAll(List.of(product1, product2));
 
             ChatRoom notMyChatRoom1 = createChatRoom(buyer1.getId(), seller1.getId(), product1.getId());

--- a/src/test/java/com/pawland/chat/repository/ChatRoomRepositoryTest.java
+++ b/src/test/java/com/pawland/chat/repository/ChatRoomRepositoryTest.java
@@ -1,0 +1,141 @@
+package com.pawland.chat.repository;
+
+import com.pawland.chat.domain.ChatRoom;
+import com.pawland.chat.dto.response.ChatRoomInfoResponse;
+import com.pawland.global.config.QueryDslConfig;
+import com.pawland.order.respository.OrderJpaRepository;
+import com.pawland.product.domain.Product;
+import com.pawland.product.respository.ProductJpaRepository;
+import com.pawland.user.domain.User;
+import com.pawland.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.util.List;
+
+import static com.pawland.product.domain.Status.SELLING;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+
+@DataJpaTest
+@Import(QueryDslConfig.class)
+class ChatRoomRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private OrderJpaRepository orderJpaRepository;
+
+    @Autowired
+    private ProductJpaRepository productJpaRepository;
+
+    @Autowired
+    private ChatRoomRepository chatRoomRepository;
+
+    @DisplayName("내 채팅방 목록 조회 시")
+    @Nested
+    class getMyChatRoomList{
+        @DisplayName("내가 구매자인 채팅방과 판매자인 채팅방을 모두 조회한다.")
+        @Test
+        void getMyChatRoomList1() {
+            // given
+            User myAccount = createUser("본인", "midcon1@naver.com", "asd123123");
+            User seller1 = createUser("판매자1", "midcon2@naver.com", "asd123123");
+            User seller2 = createUser("판매자2", "midcon3@naver.com", "asd123123");
+            User buyer1 = createUser("구매자1", "midcon4@naver.com", "asd123123");
+            userRepository.saveAll(List.of(myAccount, seller1, seller2, buyer1));
+
+            Product product1 = createProduct("나는짱물건1", 1000, "장난감", "DOG", "NEW");
+            Product product2 = createProduct("나는짱물건2", 2000, "장난감", "DOG", "NEW");
+            Product product3 = createProduct("나는짱물건3", 3000, "장난감", "DOG", "NEW");
+            product3.confirmPurchase(1L);
+            productJpaRepository.saveAll(List.of(product1, product2, product3));
+
+            ChatRoom chatRoom1 = createChatRoom(myAccount.getId(), seller1.getId(), product1.getId());
+            ChatRoom chatRoom2 = createChatRoom(myAccount.getId(), seller2.getId(), product2.getId());
+            ChatRoom chatRoom3 = createChatRoom(buyer1.getId(), myAccount.getId(), product3.getId());
+            chatRoomRepository.saveAll(List.of(chatRoom1, chatRoom2, chatRoom3));
+
+            // when
+            List<ChatRoomInfoResponse> chatRoomList = chatRoomRepository.getMyChatRoomList(myAccount.getId());
+
+            // then
+            assertThat(chatRoomList).hasSize(3);
+            assertThat(chatRoomList).extracting("opponentUser")
+                .extracting("nickname")
+                .containsExactlyInAnyOrder("판매자1", "판매자2", "구매자1");
+            assertThat(chatRoomList).extracting("productInfo")
+                .extracting("price", "productName", "saleState", "purchaser")
+                .containsExactlyInAnyOrder(
+                    tuple(1000,"나는짱물건1", SELLING, null),
+                    tuple(2000,"나는짱물건2", SELLING, null),
+                    tuple(3000,"나는짱물건3", SELLING, 1L)
+                );
+
+            List<ChatRoom> all = chatRoomRepository.findAll();
+            System.out.println("[size] " + all.size());
+            System.out.println("[size] " + all.get(0).getId());
+
+        }
+
+        @DisplayName("내가 참여하고 있는 채팅방이 없을 시 빈 리스트를 반환한다.")
+        @Test
+        void getMyChatRoomList2() {
+            User myAccount = createUser("본인", "midcon1@naver.com", "asd123123");
+            User seller1 = createUser("판매자1", "midcon2@naver.com", "asd123123");
+            User seller2 = createUser("판매자2", "midcon3@naver.com", "asd123123");
+            User buyer1 = createUser("구매자1", "midcon4@naver.com", "asd123123");
+            User buyer2 = createUser("구매자2", "midcon5@naver.com", "asd123123");
+            userRepository.saveAll(List.of(myAccount, seller1, seller2, buyer1, buyer2));
+
+            Product product1 = createProduct("나는짱물건1", 1000, "장난감", "DOG", "NEW");
+            Product product2 = createProduct("나는짱물건2", 2000, "장난감", "DOG", "NEW");
+            productJpaRepository.saveAll(List.of(product1, product2));
+
+            ChatRoom chatRoom1 = createChatRoom(buyer1.getId(), seller1.getId(), product1.getId());
+            ChatRoom chatRoom2 = createChatRoom(buyer2.getId(), seller2.getId(), product2.getId());
+            chatRoomRepository.saveAll(List.of(chatRoom1, chatRoom2));
+
+            // when
+            List<ChatRoomInfoResponse> chatRoomList = chatRoomRepository.getMyChatRoomList(myAccount.getId());
+
+            // then
+            assertThat(chatRoomList).hasSize(0);
+            List<ChatRoom> all = chatRoomRepository.findAll();
+            System.out.println("[size] " + all.size());
+            System.out.println("[size] " + all.get(0).getId());
+        }
+    }
+
+    private static User createUser(String nickname, String email, String password) {
+        return User.builder()
+            .nickname(nickname)
+            .email(email)
+            .password(password)
+            .build();
+    }
+
+    private Product createProduct(String name, int price, String category, String species, String condition) {
+        return Product.builder()
+            .name(name)
+            .price(price)
+            .category(category)
+            .species(species)
+            .condition(condition)
+            .build();
+    }
+
+    private static ChatRoom createChatRoom(Long buyerId, Long sellerId, Long productId) {
+        ChatRoom chatRoom = ChatRoom.builder()
+            .buyerId(buyerId)
+            .sellerId(sellerId)
+            .productId(productId)
+            .build();
+        return chatRoom;
+    }
+}

--- a/src/test/java/com/pawland/chat/repository/ChatRoomRepositoryTest.java
+++ b/src/test/java/com/pawland/chat/repository/ChatRoomRepositoryTest.java
@@ -51,10 +51,10 @@ class ChatRoomRepositoryTest {
             User buyer2 = createUser("구매자2", "midcon5@naver.com", "asd123123");
             userRepository.saveAll(List.of(myAccount, seller1, seller2, buyer1, buyer2));
 
-            Product product1 = createProduct("나는짱물건1", 1000, "장난감", "DOG", "NEW");
-            Product product2 = createProduct("나는짱물건2", 2000, "장난감", "DOG", "NEW");
-            Product product3 = createProduct("나는짱물건3", 3000, "장난감", "DOG", "NEW");
-            Product product4 = createProduct("나는짱물건4", 4000, "장난감", "DOG", "NEW");
+            Product product1 = createProduct("나는짱물건1", 1000, "장난감", "강아지", "새상품");
+            Product product2 = createProduct("나는짱물건2", 2000, "장난감", "강아지", "새상품");
+            Product product3 = createProduct("나는짱물건3", 3000, "장난감", "강아지", "새상품");
+            Product product4 = createProduct("나는짱물건4", 4000, "장난감", "강아지", "새상품");
             product3.confirmPurchase(1L);
             productJpaRepository.saveAll(List.of(product1, product2, product3, product4));
 
@@ -92,8 +92,8 @@ class ChatRoomRepositoryTest {
             User buyer2 = createUser("구매자2", "midcon5@naver.com", "asd123123");
             userRepository.saveAll(List.of(myAccount, seller1, seller2, buyer1, buyer2));
 
-            Product product1 = createProduct("나는짱물건1", 1000, "장난감", "DOG", "NEW");
-            Product product2 = createProduct("나는짱물건2", 2000, "장난감", "DOG", "NEW");
+            Product product1 = createProduct("나는짱물건1", 1000, "장난감", "강아지", "새상품");
+            Product product2 = createProduct("나는짱물건2", 2000, "장난감", "강아지", "새상품");
             productJpaRepository.saveAll(List.of(product1, product2));
 
             ChatRoom notMyChatRoom1 = createChatRoom(buyer1.getId(), seller1.getId(), product1.getId());

--- a/src/test/java/com/pawland/chat/repository/ChatRoomRepositoryTest.java
+++ b/src/test/java/com/pawland/chat/repository/ChatRoomRepositoryTest.java
@@ -48,39 +48,38 @@ class ChatRoomRepositoryTest {
             User seller1 = createUser("판매자1", "midcon2@naver.com", "asd123123");
             User seller2 = createUser("판매자2", "midcon3@naver.com", "asd123123");
             User buyer1 = createUser("구매자1", "midcon4@naver.com", "asd123123");
-            userRepository.saveAll(List.of(myAccount, seller1, seller2, buyer1));
+            User buyer2 = createUser("구매자2", "midcon5@naver.com", "asd123123");
+            userRepository.saveAll(List.of(myAccount, seller1, seller2, buyer1, buyer2));
 
             Product product1 = createProduct("나는짱물건1", 1000, "장난감", "DOG", "NEW");
             Product product2 = createProduct("나는짱물건2", 2000, "장난감", "DOG", "NEW");
             Product product3 = createProduct("나는짱물건3", 3000, "장난감", "DOG", "NEW");
+            Product product4 = createProduct("나는짱물건4", 4000, "장난감", "DOG", "NEW");
             product3.confirmPurchase(1L);
-            productJpaRepository.saveAll(List.of(product1, product2, product3));
+            productJpaRepository.saveAll(List.of(product1, product2, product3, product4));
 
-            ChatRoom chatRoom1 = createChatRoom(myAccount.getId(), seller1.getId(), product1.getId());
-            ChatRoom chatRoom2 = createChatRoom(myAccount.getId(), seller2.getId(), product2.getId());
-            ChatRoom chatRoom3 = createChatRoom(buyer1.getId(), myAccount.getId(), product3.getId());
-            chatRoomRepository.saveAll(List.of(chatRoom1, chatRoom2, chatRoom3));
+            ChatRoom myChatRoom1 = createChatRoom(myAccount.getId(), seller1.getId(), product1.getId());
+            ChatRoom myChatRoom2 = createChatRoom(myAccount.getId(), seller2.getId(), product2.getId());
+            ChatRoom myChatRoom3 = createChatRoom(buyer1.getId(), myAccount.getId(), product3.getId());
+            ChatRoom notMyChatRoom1 = createChatRoom(buyer1.getId(), seller2.getId(), product4.getId());
+            ChatRoom notMyChatRoom2 = createChatRoom(buyer2.getId(), seller2.getId(), product4.getId());
+            chatRoomRepository.saveAll(List.of(myChatRoom1, myChatRoom2, myChatRoom3, notMyChatRoom1, notMyChatRoom2));
 
             // when
-            List<ChatRoomInfoResponse> chatRoomList = chatRoomRepository.getMyChatRoomList(myAccount.getId());
+            List<ChatRoomInfoResponse> result = chatRoomRepository.getMyChatRoomList(myAccount.getId());
 
             // then
-            assertThat(chatRoomList).hasSize(3);
-            assertThat(chatRoomList).extracting("opponentUser")
+            assertThat(result).hasSize(3);
+            assertThat(result).extracting("opponentUser")
                 .extracting("nickname")
                 .containsExactlyInAnyOrder("판매자1", "판매자2", "구매자1");
-            assertThat(chatRoomList).extracting("productInfo")
+            assertThat(result).extracting("productInfo")
                 .extracting("price", "productName", "saleState", "purchaser")
                 .containsExactlyInAnyOrder(
                     tuple(1000,"나는짱물건1", SELLING, null),
                     tuple(2000,"나는짱물건2", SELLING, null),
                     tuple(3000,"나는짱물건3", SELLING, 1L)
                 );
-
-            List<ChatRoom> all = chatRoomRepository.findAll();
-            System.out.println("[size] " + all.size());
-            System.out.println("[size] " + all.get(0).getId());
-
         }
 
         @DisplayName("내가 참여하고 있는 채팅방이 없을 시 빈 리스트를 반환한다.")
@@ -97,18 +96,15 @@ class ChatRoomRepositoryTest {
             Product product2 = createProduct("나는짱물건2", 2000, "장난감", "DOG", "NEW");
             productJpaRepository.saveAll(List.of(product1, product2));
 
-            ChatRoom chatRoom1 = createChatRoom(buyer1.getId(), seller1.getId(), product1.getId());
-            ChatRoom chatRoom2 = createChatRoom(buyer2.getId(), seller2.getId(), product2.getId());
-            chatRoomRepository.saveAll(List.of(chatRoom1, chatRoom2));
+            ChatRoom notMyChatRoom1 = createChatRoom(buyer1.getId(), seller1.getId(), product1.getId());
+            ChatRoom notMyChatRoom2 = createChatRoom(buyer2.getId(), seller2.getId(), product2.getId());
+            chatRoomRepository.saveAll(List.of(notMyChatRoom1, notMyChatRoom2));
 
             // when
-            List<ChatRoomInfoResponse> chatRoomList = chatRoomRepository.getMyChatRoomList(myAccount.getId());
+            List<ChatRoomInfoResponse> result = chatRoomRepository.getMyChatRoomList(myAccount.getId());
 
             // then
-            assertThat(chatRoomList).hasSize(0);
-            List<ChatRoom> all = chatRoomRepository.findAll();
-            System.out.println("[size] " + all.size());
-            System.out.println("[size] " + all.get(0).getId());
+            assertThat(result).hasSize(0);
         }
     }
 

--- a/src/test/java/com/pawland/chat/service/ChatServiceTest.java
+++ b/src/test/java/com/pawland/chat/service/ChatServiceTest.java
@@ -61,7 +61,7 @@ class ChatServiceTest {
                 User seller = createUser("판매자1", "midcon2@naver.com", "asd123123");
                 userRepository.saveAll(List.of(buyer, seller));
 
-                Product product = createProduct("나는짱물건", 10000, "장난감", "DOG", "NEW");
+                Product product = createProduct("나는짱물건", 10000, "장난감", "강아지", "새상품");
                 productJpaRepository.save(product);
 
                 ChatRoomCreateRequest request = ChatRoomCreateRequest.builder()
@@ -89,7 +89,7 @@ class ChatServiceTest {
                 User seller = createUser("판매자1", "midcon2@naver.com", "asd123123");
                 userRepository.saveAll(List.of(buyer, seller));
 
-                Product product = createProduct("나는짱물건", 10000, "장난감", "DOG", "NEW");
+                Product product = createProduct("나는짱물건", 10000, "장난감", "강아지", "새상품");
                 productJpaRepository.save(product);
 
                 ChatRoomCreateRequest requestWithoutSellerId = ChatRoomCreateRequest.builder()
@@ -122,7 +122,7 @@ class ChatServiceTest {
                 User seller = createUser("판매자1", "midcon2@naver.com", "asd123123");
                 userRepository.saveAll(List.of(buyer, seller));
 
-                Product product = createProduct("나는짱물건", 10000, "장난감", "DOG", "NEW");
+                Product product = createProduct("나는짱물건", 10000, "장난감", "강아지", "새상품");
                 productJpaRepository.save(product);
 
                 ChatRoomCreateRequest request = ChatRoomCreateRequest.builder()
@@ -150,7 +150,7 @@ class ChatServiceTest {
                 User seller = createUser("판매자1", "midcon2@naver.com", "asd123123");
                 userRepository.saveAll(List.of(buyer, seller));
 
-                Product product = createProduct("나는짱물건", 10000, "장난감", "DOG", "NEW");
+                Product product = createProduct("나는짱물건", 10000, "장난감", "강아지", "새상품");
                 productJpaRepository.save(product);
 
                 Long InvalidSellerId = 0L;
@@ -192,10 +192,10 @@ class ChatServiceTest {
             User buyer2 = createUser("구매자2", "midcon5@naver.com", "asd123123");
             userRepository.saveAll(List.of(myAccount, seller1, seller2, buyer1, buyer2));
 
-            Product product1 = createProduct("나는짱물건1", 1000, "장난감", "DOG", "NEW");
-            Product product2 = createProduct("나는짱물건2", 2000, "장난감", "DOG", "NEW");
-            Product product3 = createProduct("나는짱물건3", 3000, "장난감", "DOG", "NEW");
-            Product product4 = createProduct("나는짱물건4", 4000, "장난감", "DOG", "NEW");
+            Product product1 = createProduct("나는짱물건1", 1000, "장난감", "강아지", "새상품");
+            Product product2 = createProduct("나는짱물건2", 2000, "장난감", "강아지", "새상품");
+            Product product3 = createProduct("나는짱물건3", 3000, "장난감", "강아지", "새상품");
+            Product product4 = createProduct("나는짱물건4", 4000, "장난감", "강아지", "새상품");
             product3.confirmPurchase(1L);
             productJpaRepository.saveAll(List.of(product1, product2, product3, product4));
 
@@ -233,8 +233,8 @@ class ChatServiceTest {
             User buyer2 = createUser("구매자2", "midcon5@naver.com", "asd123123");
             userRepository.saveAll(List.of(myAccount, seller1, seller2, buyer1, buyer2));
 
-            Product product1 = createProduct("나는짱물건1", 1000, "장난감", "DOG", "NEW");
-            Product product2 = createProduct("나는짱물건2", 2000, "장난감", "DOG", "NEW");
+            Product product1 = createProduct("나는짱물건1", 1000, "장난감", "강아지", "새상품");
+            Product product2 = createProduct("나는짱물건2", 2000, "장난감", "강아지", "새상품");
             productJpaRepository.saveAll(List.of(product1, product2));
 
             ChatRoom notMyChatRoom1 = createChatRoom(buyer1.getId(), seller1.getId(), product1.getId());

--- a/src/test/java/com/pawland/chat/service/ChatServiceTest.java
+++ b/src/test/java/com/pawland/chat/service/ChatServiceTest.java
@@ -2,6 +2,7 @@ package com.pawland.chat.service;
 
 import com.pawland.chat.domain.ChatRoom;
 import com.pawland.chat.dto.request.ChatRoomCreateRequest;
+import com.pawland.chat.dto.response.ChatRoomInfoResponse;
 import com.pawland.chat.repository.ChatRoomRepository;
 import com.pawland.product.domain.Product;
 import com.pawland.product.exception.ProductException;
@@ -19,8 +20,10 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.List;
 
+import static com.pawland.product.domain.Status.SELLING;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.groups.Tuple.tuple;
 
 @SpringBootTest
 class ChatServiceTest {
@@ -56,7 +59,7 @@ class ChatServiceTest {
                 // given
                 User buyer = createUser("구매자1", "midcon4@naver.com", "asd123123");
                 User seller = createUser("판매자1", "midcon2@naver.com", "asd123123");
-                userRepository.saveAll(List.of(buyer ,seller));
+                userRepository.saveAll(List.of(buyer, seller));
 
                 Product product = createProduct("나는짱물건", 10000, "장난감", "DOG", "NEW");
                 productJpaRepository.save(product);
@@ -84,7 +87,7 @@ class ChatServiceTest {
                 // given
                 User buyer = createUser("구매자1", "midcon4@naver.com", "asd123123");
                 User seller = createUser("판매자1", "midcon2@naver.com", "asd123123");
-                userRepository.saveAll(List.of(buyer ,seller));
+                userRepository.saveAll(List.of(buyer, seller));
 
                 Product product = createProduct("나는짱물건", 10000, "장난감", "DOG", "NEW");
                 productJpaRepository.save(product);
@@ -117,7 +120,7 @@ class ChatServiceTest {
                 // given
                 User buyer = createUser("구매자1", "midcon4@naver.com", "asd123123");
                 User seller = createUser("판매자1", "midcon2@naver.com", "asd123123");
-                userRepository.saveAll(List.of(buyer ,seller));
+                userRepository.saveAll(List.of(buyer, seller));
 
                 Product product = createProduct("나는짱물건", 10000, "장난감", "DOG", "NEW");
                 productJpaRepository.save(product);
@@ -145,7 +148,7 @@ class ChatServiceTest {
                 // given
                 User buyer = createUser("구매자1", "midcon4@naver.com", "asd123123");
                 User seller = createUser("판매자1", "midcon2@naver.com", "asd123123");
-                userRepository.saveAll(List.of(buyer ,seller));
+                userRepository.saveAll(List.of(buyer, seller));
 
                 Product product = createProduct("나는짱물건", 10000, "장난감", "DOG", "NEW");
                 productJpaRepository.save(product);
@@ -172,6 +175,77 @@ class ChatServiceTest {
                 assertThatThrownBy(() -> chatService.createChatRoom(buyer.getId(), requestWithInvalidProductInfo))
                     .isInstanceOf(ProductException.NotFoundProduct.class);
             }
+        }
+    }
+
+    @DisplayName("내 채팅방 목록 조회 시")
+    @Nested
+    class getMyChatRoomList {
+        @DisplayName("내가 구매자인 채팅방과 판매자인 채팅방을 모두 조회한다.")
+        @Test
+        void getMyChatRoomList1() {
+            // given
+            User myAccount = createUser("본인", "midcon1@naver.com", "asd123123");
+            User seller1 = createUser("판매자1", "midcon2@naver.com", "asd123123");
+            User seller2 = createUser("판매자2", "midcon3@naver.com", "asd123123");
+            User buyer1 = createUser("구매자1", "midcon4@naver.com", "asd123123");
+            User buyer2 = createUser("구매자2", "midcon5@naver.com", "asd123123");
+            userRepository.saveAll(List.of(myAccount, seller1, seller2, buyer1, buyer2));
+
+            Product product1 = createProduct("나는짱물건1", 1000, "장난감", "DOG", "NEW");
+            Product product2 = createProduct("나는짱물건2", 2000, "장난감", "DOG", "NEW");
+            Product product3 = createProduct("나는짱물건3", 3000, "장난감", "DOG", "NEW");
+            Product product4 = createProduct("나는짱물건4", 4000, "장난감", "DOG", "NEW");
+            product3.confirmPurchase(1L);
+            productJpaRepository.saveAll(List.of(product1, product2, product3, product4));
+
+            ChatRoom myChatRoom1 = createChatRoom(myAccount.getId(), seller1.getId(), product1.getId());
+            ChatRoom myChatRoom2 = createChatRoom(myAccount.getId(), seller2.getId(), product2.getId());
+            ChatRoom myChatRoom3 = createChatRoom(buyer1.getId(), myAccount.getId(), product3.getId());
+            ChatRoom notMyChatRoom1 = createChatRoom(buyer1.getId(), seller2.getId(), product4.getId());
+            ChatRoom notMyChatRoom2 = createChatRoom(buyer2.getId(), seller2.getId(), product4.getId());
+            chatRoomRepository.saveAll(List.of(myChatRoom1, myChatRoom2, myChatRoom3, notMyChatRoom1, notMyChatRoom2));
+
+            // when
+            List<ChatRoomInfoResponse> result = chatRoomRepository.getMyChatRoomList(myAccount.getId());
+
+            // then
+            assertThat(result).hasSize(3);
+            assertThat(result).extracting("opponentUser")
+                .extracting("nickname")
+                .containsExactlyInAnyOrder("판매자1", "판매자2", "구매자1");
+            assertThat(result).extracting("productInfo")
+                .extracting("price", "productName", "saleState", "purchaser")
+                .containsExactlyInAnyOrder(
+                    tuple(1000, "나는짱물건1", SELLING, null),
+                    tuple(2000, "나는짱물건2", SELLING, null),
+                    tuple(3000, "나는짱물건3", SELLING, 1L)
+                );
+        }
+
+        @DisplayName("내가 참여하고 있는 채팅방이 없을 시 빈 리스트를 반환한다.")
+        @Test
+        void getMyChatRoomList2() {
+            User myAccount = createUser("본인", "midcon1@naver.com", "asd123123");
+            User seller1 = createUser("판매자1", "midcon2@naver.com", "asd123123");
+            User seller2 = createUser("판매자2", "midcon3@naver.com", "asd123123");
+            User buyer1 = createUser("구매자1", "midcon4@naver.com", "asd123123");
+            User buyer2 = createUser("구매자2", "midcon5@naver.com", "asd123123");
+            userRepository.saveAll(List.of(myAccount, seller1, seller2, buyer1, buyer2));
+
+            Product product1 = createProduct("나는짱물건1", 1000, "장난감", "DOG", "NEW");
+            Product product2 = createProduct("나는짱물건2", 2000, "장난감", "DOG", "NEW");
+            productJpaRepository.saveAll(List.of(product1, product2));
+
+            ChatRoom notMyChatRoom1 = createChatRoom(buyer1.getId(), seller1.getId(), product1.getId());
+            ChatRoom notMyChatRoom2 = createChatRoom(buyer2.getId(), seller2.getId(), product2.getId());
+            chatRoomRepository.saveAll(List.of(notMyChatRoom1, notMyChatRoom2));
+
+            // when
+            List<ChatRoomInfoResponse> result = chatRoomRepository.getMyChatRoomList(myAccount.getId());
+
+            // then
+            assertThat(result).hasSize(0);
         }
     }
 

--- a/src/test/java/com/pawland/chat/service/ChatServiceTest.java
+++ b/src/test/java/com/pawland/chat/service/ChatServiceTest.java
@@ -54,27 +54,11 @@ class ChatServiceTest {
             @Test
             void createChatRoom1() {
                 // given
-                User buyer = User.builder()
-                    .nickname("구매자")
-                    .email("midcon1@nav.com")
-                    .password("asd123123")
-                    .build();
-                userRepository.save(buyer);
+                User buyer = createUser("구매자1", "midcon4@naver.com", "asd123123");
+                User seller = createUser("판매자1", "midcon2@naver.com", "asd123123");
+                userRepository.saveAll(List.of(buyer ,seller));
 
-                User seller = User.builder()
-                    .nickname("판매자")
-                    .email("midcon2@nav.com")
-                    .password("asd123123")
-                    .build();
-                userRepository.save(seller);
-
-                Product product = Product.builder()
-                    .name("나는짱물건")
-                    .price(10000)
-                    .category("장난감")
-                    .species("DOG")
-                    .condition("NEW")
-                    .build();
+                Product product = createProduct("나는짱물건", 10000, "장난감", "DOG", "NEW");
                 productJpaRepository.save(product);
 
                 ChatRoomCreateRequest request = ChatRoomCreateRequest.builder()
@@ -98,27 +82,11 @@ class ChatServiceTest {
             @Test
             void createChatRoom2() {
                 // given
-                User buyer = User.builder()
-                    .nickname("구매자")
-                    .email("midcon1@nav.com")
-                    .password("asd123123")
-                    .build();
-                userRepository.save(buyer);
+                User buyer = createUser("구매자1", "midcon4@naver.com", "asd123123");
+                User seller = createUser("판매자1", "midcon2@naver.com", "asd123123");
+                userRepository.saveAll(List.of(buyer ,seller));
 
-                User seller = User.builder()
-                    .nickname("판매자")
-                    .email("midcon2@nav.com")
-                    .password("asd123123")
-                    .build();
-                userRepository.save(seller);
-
-                Product product = Product.builder()
-                    .name("나는짱물건")
-                    .price(10000)
-                    .category("장난감")
-                    .species("DOG")
-                    .condition("NEW")
-                    .build();
+                Product product = createProduct("나는짱물건", 10000, "장난감", "DOG", "NEW");
                 productJpaRepository.save(product);
 
                 ChatRoomCreateRequest requestWithoutSellerId = ChatRoomCreateRequest.builder()
@@ -147,27 +115,11 @@ class ChatServiceTest {
             @Test
             void createChatRoom1() {
                 // given
-                User buyer = User.builder()
-                    .nickname("구매자")
-                    .email("midcon1@nav.com")
-                    .password("asd123123")
-                    .build();
-                userRepository.save(buyer);
+                User buyer = createUser("구매자1", "midcon4@naver.com", "asd123123");
+                User seller = createUser("판매자1", "midcon2@naver.com", "asd123123");
+                userRepository.saveAll(List.of(buyer ,seller));
 
-                User seller = User.builder()
-                    .nickname("판매자")
-                    .email("midcon2@nav.com")
-                    .password("asd123123")
-                    .build();
-                userRepository.save(seller);
-
-                Product product = Product.builder()
-                    .name("나는짱물건")
-                    .price(10000)
-                    .category("장난감")
-                    .species("DOG")
-                    .condition("NEW")
-                    .build();
+                Product product = createProduct("나는짱물건", 10000, "장난감", "DOG", "NEW");
                 productJpaRepository.save(product);
 
                 ChatRoomCreateRequest request = ChatRoomCreateRequest.builder()
@@ -191,27 +143,11 @@ class ChatServiceTest {
             @Test
             void createChatRoom2() {
                 // given
-                User buyer = User.builder()
-                    .nickname("구매자")
-                    .email("midcon1@nav.com")
-                    .password("asd123123")
-                    .build();
-                userRepository.save(buyer);
+                User buyer = createUser("구매자1", "midcon4@naver.com", "asd123123");
+                User seller = createUser("판매자1", "midcon2@naver.com", "asd123123");
+                userRepository.saveAll(List.of(buyer ,seller));
 
-                User seller = User.builder()
-                    .nickname("판매자")
-                    .email("midcon2@nav.com")
-                    .password("asd123123")
-                    .build();
-                userRepository.save(seller);
-
-                Product product = Product.builder()
-                    .name("나는짱물건")
-                    .price(10000)
-                    .category("장난감")
-                    .species("DOG")
-                    .condition("NEW")
-                    .build();
+                Product product = createProduct("나는짱물건", 10000, "장난감", "DOG", "NEW");
                 productJpaRepository.save(product);
 
                 Long InvalidSellerId = 0L;
@@ -237,5 +173,32 @@ class ChatServiceTest {
                     .isInstanceOf(ProductException.NotFoundProduct.class);
             }
         }
+    }
+
+    private static User createUser(String nickname, String email, String password) {
+        return User.builder()
+            .nickname(nickname)
+            .email(email)
+            .password(password)
+            .build();
+    }
+
+    private Product createProduct(String name, int price, String category, String species, String condition) {
+        return Product.builder()
+            .name(name)
+            .price(price)
+            .category(category)
+            .species(species)
+            .condition(condition)
+            .build();
+    }
+
+    private static ChatRoom createChatRoom(Long buyerId, Long sellerId, Long productId) {
+        ChatRoom chatRoom = ChatRoom.builder()
+            .buyerId(buyerId)
+            .sellerId(sellerId)
+            .productId(productId)
+            .build();
+        return chatRoom;
     }
 }

--- a/src/test/java/com/pawland/chat/service/ChatServiceTest.java
+++ b/src/test/java/com/pawland/chat/service/ChatServiceTest.java
@@ -1,0 +1,241 @@
+package com.pawland.chat.service;
+
+import com.pawland.chat.domain.ChatRoom;
+import com.pawland.chat.dto.request.ChatRoomCreateRequest;
+import com.pawland.chat.repository.ChatRoomRepository;
+import com.pawland.product.domain.Product;
+import com.pawland.product.exception.ProductException;
+import com.pawland.product.respository.ProductJpaRepository;
+import com.pawland.user.domain.User;
+import com.pawland.user.exception.UserException;
+import com.pawland.user.repository.UserRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+class ChatServiceTest {
+
+    @Autowired
+    private ChatService chatService;
+
+    @Autowired
+    private ProductJpaRepository productJpaRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ChatRoomRepository chatRoomRepository;
+
+    @AfterEach
+    void tearDown() {
+        userRepository.deleteAll();
+        productJpaRepository.deleteAllInBatch();
+        chatRoomRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("채팅방 생성 시")
+    @Nested
+    class createChatRoom {
+        @DisplayName("요청 값 관련 테스트")
+        @Nested
+        class createChatRoom2 {
+            @DisplayName("요청 값에 구매자 ID, 판매자 ID, 상품 ID가 모두 들어있으면 성공한다.")
+            @Test
+            void createChatRoom1() {
+                // given
+                User buyer = User.builder()
+                    .nickname("구매자")
+                    .email("midcon1@nav.com")
+                    .password("asd123123")
+                    .build();
+                userRepository.save(buyer);
+
+                User seller = User.builder()
+                    .nickname("판매자")
+                    .email("midcon2@nav.com")
+                    .password("asd123123")
+                    .build();
+                userRepository.save(seller);
+
+                Product product = Product.builder()
+                    .name("나는짱물건")
+                    .price(10000)
+                    .category("장난감")
+                    .species("DOG")
+                    .condition("NEW")
+                    .build();
+                productJpaRepository.save(product);
+
+                ChatRoomCreateRequest request = ChatRoomCreateRequest.builder()
+                    .sellerId(seller.getId())
+                    .productId(product.getId())
+                    .build();
+
+                // when
+                chatService.createChatRoom(buyer.getId(), request);
+                List<ChatRoom> chatRoomList = chatRoomRepository.findAll();
+                ChatRoom result = chatRoomList.get(0);
+
+                // then
+                assertThat(chatRoomList.size()).isEqualTo(1L);
+                assertThat(result.getBuyerId()).isEqualTo(buyer.getId());
+                assertThat(result.getSellerId()).isEqualTo(seller.getId());
+                assertThat(result.getProductId()).isEqualTo(product.getId());
+            }
+
+            @DisplayName("요청 값에 구매자, 판매자, 상품의 ID 중 하나라도 없으면 예외를 던진다.")
+            @Test
+            void createChatRoom2() {
+                // given
+                User buyer = User.builder()
+                    .nickname("구매자")
+                    .email("midcon1@nav.com")
+                    .password("asd123123")
+                    .build();
+                userRepository.save(buyer);
+
+                User seller = User.builder()
+                    .nickname("판매자")
+                    .email("midcon2@nav.com")
+                    .password("asd123123")
+                    .build();
+                userRepository.save(seller);
+
+                Product product = Product.builder()
+                    .name("나는짱물건")
+                    .price(10000)
+                    .category("장난감")
+                    .species("DOG")
+                    .condition("NEW")
+                    .build();
+                productJpaRepository.save(product);
+
+                ChatRoomCreateRequest requestWithoutSellerId = ChatRoomCreateRequest.builder()
+                    .productId(product.getId())
+                    .build();
+
+                ChatRoomCreateRequest requestWithoutProductId = ChatRoomCreateRequest.builder()
+                    .sellerId(seller.getId())
+                    .build();
+
+                List<ChatRoom> result = chatRoomRepository.findAll();
+
+                // expected
+                assertThat(result.size()).isEqualTo(0L);
+                assertThatThrownBy(() -> chatService.createChatRoom(buyer.getId(), requestWithoutSellerId))
+                    .isInstanceOf(RuntimeException.class);
+                assertThatThrownBy(() -> chatService.createChatRoom(buyer.getId(), requestWithoutProductId))
+                    .isInstanceOf(RuntimeException.class);
+            }
+        }
+
+        @DisplayName("DB 정보 관련 테스트")
+        @Nested
+        class createChatRoom1 {
+            @DisplayName("요청 값에 담긴 정보로 DB에서 판매자, 상품 정보 조회가 가능하면 성공한다.")
+            @Test
+            void createChatRoom1() {
+                // given
+                User buyer = User.builder()
+                    .nickname("구매자")
+                    .email("midcon1@nav.com")
+                    .password("asd123123")
+                    .build();
+                userRepository.save(buyer);
+
+                User seller = User.builder()
+                    .nickname("판매자")
+                    .email("midcon2@nav.com")
+                    .password("asd123123")
+                    .build();
+                userRepository.save(seller);
+
+                Product product = Product.builder()
+                    .name("나는짱물건")
+                    .price(10000)
+                    .category("장난감")
+                    .species("DOG")
+                    .condition("NEW")
+                    .build();
+                productJpaRepository.save(product);
+
+                ChatRoomCreateRequest request = ChatRoomCreateRequest.builder()
+                    .sellerId(seller.getId())
+                    .productId(product.getId())
+                    .build();
+
+                // when
+                chatService.createChatRoom(buyer.getId(), request);
+                List<ChatRoom> chatRoomList = chatRoomRepository.findAll();
+                ChatRoom result = chatRoomList.get(0);
+
+                // then
+                assertThat(chatRoomList.size()).isEqualTo(1L);
+                assertThat(result.getBuyerId()).isEqualTo(buyer.getId());
+                assertThat(result.getSellerId()).isEqualTo(seller.getId());
+                assertThat(result.getProductId()).isEqualTo(product.getId());
+            }
+
+            @DisplayName("요청 값에 담긴 정보로 DB에서 판매자, 상품 정보 중 하나라도 조회하지 못하면 예외를 던진다.")
+            @Test
+            void createChatRoom2() {
+                // given
+                User buyer = User.builder()
+                    .nickname("구매자")
+                    .email("midcon1@nav.com")
+                    .password("asd123123")
+                    .build();
+                userRepository.save(buyer);
+
+                User seller = User.builder()
+                    .nickname("판매자")
+                    .email("midcon2@nav.com")
+                    .password("asd123123")
+                    .build();
+                userRepository.save(seller);
+
+                Product product = Product.builder()
+                    .name("나는짱물건")
+                    .price(10000)
+                    .category("장난감")
+                    .species("DOG")
+                    .condition("NEW")
+                    .build();
+                productJpaRepository.save(product);
+
+                Long InvalidSellerId = 0L;
+                Long InvalidProductId = 0L;
+
+                ChatRoomCreateRequest requestWithInvalidSellerInfo = ChatRoomCreateRequest.builder()
+                    .sellerId(InvalidSellerId)
+                    .productId(product.getId())
+                    .build();
+
+                ChatRoomCreateRequest requestWithInvalidProductInfo = ChatRoomCreateRequest.builder()
+                    .sellerId(seller.getId())
+                    .productId(InvalidProductId)
+                    .build();
+
+                List<ChatRoom> result = chatRoomRepository.findAll();
+
+                // expected
+                assertThat(result.size()).isEqualTo(0L);
+                assertThatThrownBy(() -> chatService.createChatRoom(buyer.getId(), requestWithInvalidSellerInfo))
+                    .isInstanceOf(UserException.NotFoundUser.class);
+                assertThatThrownBy(() -> chatService.createChatRoom(buyer.getId(), requestWithInvalidProductInfo))
+                    .isInstanceOf(ProductException.NotFoundProduct.class);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 🛠️주요 변경 사항
- 채팅방 생성 / 내 채팅방 조회 기능을 추가했습니다.
- Product에 purchaser 필드가 필요해서 관련 로직 추가했습니다.
- DTO에 채팅방, 상품, 유저 정보가 필요해서 쿼리를 여러개로 분리할지
  한방 쿼리로 DTO projection할지 고민하다가 후자로 선택했습니다.