### PR TITLE
feat: 회원가입 시 랜덤 프로필 이미지 지정 로직 구현

### DIFF
--- a/src/main/java/com/pawland/auth/controller/AuthController.java
+++ b/src/main/java/com/pawland/auth/controller/AuthController.java
@@ -90,7 +90,6 @@ public class AuthController {
     @PostMapping(value = "/signup", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ApiMessageResponse> signup(@Valid @RequestBody SignupRequest request) {
         String jwtCookie = authFacade.signup(request);
-
         return ResponseEntity
             .status(CREATED)
             .header(HttpHeaders.SET_COOKIE, jwtCookie)

--- a/src/main/java/com/pawland/auth/facade/AuthFacade.java
+++ b/src/main/java/com/pawland/auth/facade/AuthFacade.java
@@ -4,6 +4,7 @@ import com.pawland.auth.dto.request.SignupRequest;
 import com.pawland.auth.dto.request.VerifyCodeRequest;
 import com.pawland.auth.service.AuthService;
 import com.pawland.global.config.security.JwtUtils;
+import com.pawland.global.domain.DefaultImage;
 import com.pawland.mail.service.MailVerificationService;
 import com.pawland.user.domain.User;
 import com.pawland.user.service.UserService;
@@ -46,6 +47,7 @@ public class AuthFacade {
         User user = User.builder()
             .email(request.getEmail())
             .password(passwordEncoder.encode(request.getPassword()))
+            .profileImage(DefaultImage.getRandomProfileImage())
             .nickname(request.getNickname())
             .build();
         userService.register(user);

--- a/src/main/java/com/pawland/global/domain/DefaultImage.java
+++ b/src/main/java/com/pawland/global/domain/DefaultImage.java
@@ -2,15 +2,35 @@ package com.pawland.global.domain;
 
 import lombok.RequiredArgsConstructor;
 
+import java.util.List;
+import java.util.Random;
+
 @RequiredArgsConstructor
 public enum DefaultImage {
 
-    DEFAULT_PROFILE_IMAGE("https://midcon-bucket.s3.ap-northeast-2.amazonaws.com/myKey4"),
+    DEFAULT_PROFILE_IMAGE_1("https://midcon-bucket.s3.ap-northeast-2.amazonaws.com/pawlandRP_1.png"),
+    DEFAULT_PROFILE_IMAGE_2("https://midcon-bucket.s3.ap-northeast-2.amazonaws.com/pawlandRP_2.png"),
+    DEFAULT_PROFILE_IMAGE_3("https://midcon-bucket.s3.ap-northeast-2.amazonaws.com/pawlandRP_3.png"),
+    DEFAULT_PROFILE_IMAGE_4("https://midcon-bucket.s3.ap-northeast-2.amazonaws.com/pawlandRP_4.png"),
+    DEFAULT_PROFILE_IMAGE_5("https://midcon-bucket.s3.ap-northeast-2.amazonaws.com/pawlandRP_5.png"),
     DEFAULT_POST_IMAGE("https://midcon-bucket.s3.ap-northeast-2.amazonaws.com/myKey4");
 
     private final String imageUrl;
 
     public String value() {
         return imageUrl;
+    }
+
+    public static String getRandomProfileImage() {
+        List<DefaultImage> defaultProfileImageList = List.of(
+            DEFAULT_PROFILE_IMAGE_1,
+            DEFAULT_PROFILE_IMAGE_2,
+            DEFAULT_PROFILE_IMAGE_3,
+            DEFAULT_PROFILE_IMAGE_4,
+            DEFAULT_PROFILE_IMAGE_5
+        );
+        Random random = new Random();
+        int index = random.nextInt(defaultProfileImageList.size());
+        return defaultProfileImageList.get(index).value();
     }
 }

--- a/src/main/java/com/pawland/user/domain/User.java
+++ b/src/main/java/com/pawland/user/domain/User.java
@@ -20,7 +20,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static com.pawland.global.domain.DefaultImage.DEFAULT_PROFILE_IMAGE;
 import static com.pawland.user.domain.LoginType.NORMAL;
 
 @Entity
@@ -53,7 +52,7 @@ public class User extends BaseTimeEntity {
     private LoginType type = NORMAL;
 
     @NotNull
-    private String profileImage = DEFAULT_PROFILE_IMAGE.value();
+    private String profileImage = "";
 
     @OneToMany(mappedBy = "buyer", orphanRemoval = true)
     private List<Order> orderList = new ArrayList<>();    // 주문 내역

--- a/src/main/java/com/pawland/user/service/UserService.java
+++ b/src/main/java/com/pawland/user/service/UserService.java
@@ -53,7 +53,9 @@ public class UserService {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(UserException.NotFoundUser::new);
 
-        checkNicknameDuplicate(request.getNickname());
+        if (isNicknameChanged(request.getNickname(), user)) {
+            checkNicknameDuplicate(request.getNickname());
+        }
         user.updateProfile(request.toUser());
         return new UserInfoUpdateResponse(user);
     }
@@ -62,5 +64,9 @@ public class UserService {
         User user = userRepository.findById(userId).orElseThrow(UserException.NotFoundUser::new);
 
         return new UserInfoResponse(user);
+    }
+
+    private static boolean isNicknameChanged(String requestNickname, User user) {
+        return !requestNickname.equals(user.getNickname());
     }
 }

--- a/src/test/java/com/pawland/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/pawland/auth/controller/AuthControllerTest.java
@@ -563,7 +563,7 @@ class AuthControllerTest {
             User oauth2User = OAuthAttributes.builder()
                     .email(email + "/" + LoginType.KAKAO.value())
                     .nickname("임시 닉네임")
-                    .profileImage(DefaultImage.DEFAULT_PROFILE_IMAGE.value())
+                    .profileImage(DefaultImage.DEFAULT_PROFILE_IMAGE_1.value())
                     .provider(LoginType.KAKAO.value())
                     .build()
                     .toUser();

--- a/src/test/java/com/pawland/user/domain/UserTest.java
+++ b/src/test/java/com/pawland/user/domain/UserTest.java
@@ -4,7 +4,6 @@ import com.pawland.user.dto.request.UserInfoUpdateRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static com.pawland.global.domain.DefaultImage.DEFAULT_PROFILE_IMAGE;
 import static com.pawland.user.domain.LoginType.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -23,7 +22,7 @@ class UserTest {
 
         // expected
         assertThat(result.getType()).isEqualTo(NORMAL);
-        assertThat(result.getProfileImage()).isEqualTo(DEFAULT_PROFILE_IMAGE.value());
+        assertThat(result.getProfileImage()).isEqualTo("");
         assertThat(result.getIntroduce()).isEqualTo("");
     }
 


### PR DESCRIPTION
## 🛠️주요 변경 사항
- 회원가입 시 프로필 사진을 변경 했습니다.
- 회원 5개의 기본 이미지 중 하나가 랜덤으로 지정됩니다.
- #39 에서 프로필 정보 수정 로직을 바꿔뒀었는데 #40 에서 롤백 됐었군요. 
PR에서 확인을 못하고 승인했었나봐요. 그 부분 다시 수정해서 올렸습니다!

## ❗관련이슈
- closed: #39 #40