### PR TITLE
feat: @ActiveProfiles로 테스트 환경설정 분리

### DIFF
--- a/src/test/java/com/pawland/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/pawland/auth/controller/AuthControllerTest.java
@@ -23,6 +23,7 @@ import org.springframework.http.MediaType;
 import org.springframework.mail.MailAuthenticationException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.Duration;
@@ -39,6 +40,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@ActiveProfiles("local")
 class AuthControllerTest {
 
     @Autowired

--- a/src/test/java/com/pawland/chat/repository/ChatMessageRepositoryTest.java
+++ b/src/test/java/com/pawland/chat/repository/ChatMessageRepositoryTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.groups.Tuple.tuple;
 
 @DataJpaTest
 @Import(QueryDslConfig.class)
-@ActiveProfiles("test")
+@ActiveProfiles("local")
 class ChatMessageRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/pawland/chat/repository/ChatRoomRepositoryTest.java
+++ b/src/test/java/com/pawland/chat/repository/ChatRoomRepositoryTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.groups.Tuple.tuple;
 
 @DataJpaTest
 @Import(QueryDslConfig.class)
-@ActiveProfiles("test")
+@ActiveProfiles("local")
 class ChatRoomRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/pawland/chat/service/ChatServiceTest.java
+++ b/src/test/java/com/pawland/chat/service/ChatServiceTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -35,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.groups.Tuple.tuple;
 
 @SpringBootTest
+@ActiveProfiles("local")
 class ChatServiceTest {
 
     @Autowired

--- a/src/test/java/com/pawland/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/pawland/comment/service/CommentServiceTest.java
@@ -19,11 +19,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.NoSuchElementException;
 
 @SpringBootTest
+@ActiveProfiles("local")
 class CommentServiceTest {
 
     @Autowired

--- a/src/test/java/com/pawland/image/service/ImageServiceTest.java
+++ b/src/test/java/com/pawland/image/service/ImageServiceTest.java
@@ -5,10 +5,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
+@ActiveProfiles("local")
 class ImageServiceTest {
 
     @Autowired

--- a/src/test/java/com/pawland/mail/service/MailVerificationServiceTest.java
+++ b/src/test/java/com/pawland/mail/service/MailVerificationServiceTest.java
@@ -17,6 +17,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mail.MailAuthenticationException;
 import org.springframework.mail.MailSendException;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.io.UnsupportedEncodingException;
 import java.time.Duration;
@@ -26,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
 @SpringBootTest
+@ActiveProfiles("local")
 class MailVerificationServiceTest {
 
     @Autowired

--- a/src/test/java/com/pawland/order/service/OrderServiceTest.java
+++ b/src/test/java/com/pawland/order/service/OrderServiceTest.java
@@ -14,12 +14,14 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @SpringBootTest
+@ActiveProfiles("local")
 class OrderServiceTest {
     @Autowired
     UserRepository userRepository;

--- a/src/test/java/com/pawland/post/service/PostServiceTest.java
+++ b/src/test/java/com/pawland/post/service/PostServiceTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 
@@ -21,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
+@ActiveProfiles("local")
 class PostServiceTest {
 
     @Autowired

--- a/src/test/java/com/pawland/product/service/ProductServiceTest.java
+++ b/src/test/java/com/pawland/product/service/ProductServiceTest.java
@@ -14,11 +14,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @SpringBootTest
+@ActiveProfiles("local")
 class ProductServiceTest {
 
     @Autowired

--- a/src/test/java/com/pawland/review/ReviewServiceTest.java
+++ b/src/test/java/com/pawland/review/ReviewServiceTest.java
@@ -16,9 +16,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
+@ActiveProfiles("local")
 class ReviewServiceTest {
     @Autowired
     UserRepository userRepository;

--- a/src/test/java/com/pawland/user/service/UserServiceTest.java
+++ b/src/test/java/com/pawland/user/service/UserServiceTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.TransactionSystemException;
 
 import java.util.List;
@@ -20,6 +21,7 @@ import static com.pawland.user.exception.UserExceptionMessage.*;
 import static org.assertj.core.api.Assertions.*;
 
 @SpringBootTest
+@ActiveProfiles("local")
 class UserServiceTest {
 
     @Autowired


### PR DESCRIPTION
## 🛠️주요 변경 사항
- yml을 prod로 설정하고 RDS 를 사용하는 환경으로 전환하려니까 빌드할때 
테스트 코드들이 RDS의 MySQL 환경에서 동작해서 사이드이팩트가 남길래 우선 프로필로 분리했습니다.

## 📣리뷰어가 꼭 알아야 하는 사항
- 컨트롤러는 TestSecurityConfig를 사용해야해서 test 프로필을 사용합니다.
- 서비스, 리포지토리는 local 프로필을 사용합니다.