### PR TITLE
feat: 채팅방 목록 조회 시 응답 값에 각 채팅방의 마지막 메시지 추가

### DIFF
--- a/src/main/java/com/pawland/auth/controller/AuthController.java
+++ b/src/main/java/com/pawland/auth/controller/AuthController.java
@@ -121,7 +121,7 @@ public class AuthController {
         return ResponseEntity
             .status(HttpStatus.FOUND)
             .header(HttpHeaders.SET_COOKIE, jwtCookie)
-            .header(HttpHeaders.LOCATION, appConfig.getFrontTestUrl())
+            .header(HttpHeaders.LOCATION, appConfig.getFrontDeployUrl())
             .body(new ApiMessageResponse("소셜 로그인에 성공했습니다."));
     }
 

--- a/src/main/java/com/pawland/chat/dto/response/ChatRoomInfoResponse.java
+++ b/src/main/java/com/pawland/chat/dto/response/ChatRoomInfoResponse.java
@@ -1,5 +1,6 @@
 package com.pawland.chat.dto.response;
 
+import com.pawland.chat.domain.ChatMessage;
 import com.pawland.product.domain.Status;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
@@ -12,12 +13,19 @@ public class ChatRoomInfoResponse {
     private Long orderId;
     private UserInfo opponentUser;
     private ProductInfo productInfo;
+    private LastMessage lastMessage;
 
+    @Builder
     public ChatRoomInfoResponse(Long roomId, Long orderId, UserInfo opponentUser, ProductInfo productInfo) {
         this.roomId = roomId;
         this.orderId = orderId;
         this.opponentUser = opponentUser;
         this.productInfo = productInfo;
+    }
+
+    public ChatRoomInfoResponse of(ChatMessage chatMessage) {
+        this.lastMessage = LastMessage.of(chatMessage);
+        return this;
     }
 
     @Getter
@@ -41,7 +49,7 @@ public class ChatRoomInfoResponse {
         private int price;
         private String productName;
         private String thumbnailImage;
-        private Status saleState;
+        private String saleState;
         private Long purchaser;
 
         public ProductInfo(Long id, int price, String productName,
@@ -50,8 +58,37 @@ public class ChatRoomInfoResponse {
             this.price = price;
             this.productName = productName;
             this.thumbnailImage = thumbnailImage;
-            this.saleState = saleState;
+            this.saleState = saleState.getName();
             this.purchaser = purchaser;
+        }
+    }
+
+    @Getter
+    @Schema(name = "채팅 상대의 유저 정보")
+    public static class LastMessage {
+        private String messageId;
+        private Long sender;
+        private String message;
+        private String messageTime;
+
+        @Builder
+        public LastMessage(String messageId, Long sender, String message, String messageTime) {
+            this.messageId = messageId;
+            this.sender = sender;
+            this.message = message;
+            this.messageTime = messageTime;
+        }
+
+        public static LastMessage of(ChatMessage chatMessage) {
+            if (chatMessage == null) {
+                return null;
+            }
+            return LastMessage.builder()
+                .messageId(chatMessage.getId())
+                .sender(chatMessage.getSenderId())
+                .message(chatMessage.getMessage())
+                .messageTime(chatMessage.getMessageTime().toString())
+                .build();
         }
     }
 }

--- a/src/main/java/com/pawland/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/pawland/chat/repository/ChatMessageRepository.java
@@ -2,7 +2,13 @@ package com.pawland.chat.repository;
 
 import com.pawland.chat.domain.ChatMessage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long>, ChatMessageRepositoryCustom {
 
+    @Query(value = "SELECT * FROM chat_message cm WHERE cm.room_id = :roomId ORDER BY message_time DESC LIMIT 1", nativeQuery = true)
+    Optional<ChatMessage> getLastMessage(@Param("roomId") Long roomId);
 }

--- a/src/main/java/com/pawland/chat/service/ChatService.java
+++ b/src/main/java/com/pawland/chat/service/ChatService.java
@@ -40,7 +40,9 @@ public class ChatService {
     }
 
     public List<ChatRoomInfoResponse> getChatRoomList(Long userId) {
-        return chatRoomRepository.getMyChatRoomList(userId);
+        return chatRoomRepository.getMyChatRoomList(userId).stream()
+            .map(roomInfo -> roomInfo.of(getLastMessage(roomInfo.getRoomId())))
+            .toList();
     }
 
     @Transactional
@@ -59,6 +61,11 @@ public class ChatService {
         } else {
             return ChatMessageHistoryResponse.of(null, messageList);
         }
+    }
+
+    private ChatMessage getLastMessage(Long roomId) {
+        return chatMessageRepository.getLastMessage(roomId)
+            .orElse(null);
     }
 
     private void validateChatRoomCreateRequest(ChatRoomCreateRequest request) {

--- a/src/test/java/com/pawland/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/pawland/auth/controller/AuthControllerTest.java
@@ -582,7 +582,7 @@ class AuthControllerTest {
                     )
                     .andDo(print())
                     .andExpect(status().isFound())
-                    .andExpect(redirectedUrl(appConfig.getFrontTestUrl()))
+                    .andExpect(redirectedUrl(appConfig.getFrontDeployUrl()))
                     .andExpect(jsonPath("$.message").value("소셜 로그인에 성공했습니다."))
                     .andExpect(cookie().exists("jwt"));
         }

--- a/src/test/java/com/pawland/chat/repository/ChatRoomRepositoryTest.java
+++ b/src/test/java/com/pawland/chat/repository/ChatRoomRepositoryTest.java
@@ -86,9 +86,9 @@ class ChatRoomRepositoryTest {
             assertThat(result).extracting("productInfo")
                 .extracting("price", "productName", "saleState", "purchaser")
                 .containsExactlyInAnyOrder(
-                    tuple(1000,"나는짱물건1", SELLING, null),
-                    tuple(2000,"나는짱물건2", SELLING, null),
-                    tuple(3000,"나는짱물건3", SELLING, 1L)
+                    tuple(1000,"나는짱물건1", "판매중", null),
+                    tuple(2000,"나는짱물건2", "판매중", null),
+                    tuple(3000,"나는짱물건3", "판매중", 1L)
                 );
         }
 

--- a/src/test/java/com/pawland/chat/service/ChatServiceTest.java
+++ b/src/test/java/com/pawland/chat/service/ChatServiceTest.java
@@ -278,9 +278,9 @@ class ChatServiceTest {
             assertThat(result).extracting("productInfo")
                 .extracting("price", "productName", "saleState", "purchaser")
                 .containsExactlyInAnyOrder(
-                    tuple(1000, "나는짱물건1", SELLING, null),
-                    tuple(2000, "나는짱물건2", SELLING, null),
-                    tuple(3000, "나는짱물건3", SELLING, 1L)
+                    tuple(1000, "나는짱물건1", "판매중", null),
+                    tuple(2000, "나는짱물건2", "판매중", null),
+                    tuple(3000, "나는짱물건3", "판매중", 1L)
                 );
         }
 


### PR DESCRIPTION
## 🛠️주요 변경 사항
- 채팅방 목록 조회 시 응답 값에 각 채팅방의 마지막 메시지를 추가했습니다.
- 소셜 로그인 시 리다이렉트를 localhost:3000 -> 프론트 배포 URL로 변경했습니다.

## ❗관련이슈
- closed: #35 