### PR TITLE
feat: 주문 중복 생성 방지 로직 추가

### DIFF
--- a/src/main/java/com/pawland/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/pawland/global/exception/GlobalExceptionHandler.java
@@ -2,10 +2,12 @@ package com.pawland.global.exception;
 
 import com.pawland.global.dto.ApiMessageResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mail.MailSendException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,6 +15,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
+@RequiredArgsConstructor
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(PawLandException.class)
@@ -21,6 +24,17 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity
             .status(e.getStatusCode())
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(new ApiMessageResponse(e.getMessage()));
+    }
+
+    @ResponseStatus(HttpStatus.FOUND)
+    @ExceptionHandler(AccessDeniedException.class)
+    @RequestMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponse(responseCode = "302", description = "이미 같은 리소스가 존재합니다.")
+    public ResponseEntity<ApiMessageResponse> accessDeniedExceptionHandler(AccessDeniedException e) {
+        return ResponseEntity
+            .status(HttpStatus.FOUND)
             .contentType(MediaType.APPLICATION_JSON)
             .body(new ApiMessageResponse(e.getMessage()));
     }

--- a/src/main/java/com/pawland/order/exception/OrderExceptionMessage.java
+++ b/src/main/java/com/pawland/order/exception/OrderExceptionMessage.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 public enum OrderExceptionMessage {
 
     ORDER_NOT_FOUND("상품을 찾을수 없습니다."),
-    ACCESS_DENIED_EXCEPTION("변경 권한이 없습니다.");
+    ACCESS_DENIED_EXCEPTION("변경 권한이 없습니다."),
+    ALREADY_EXISTS_ORDER("이미 주문이 있습니다.");
 
     private final String message;
 

--- a/src/main/java/com/pawland/order/respository/OrderJpaRepository.java
+++ b/src/main/java/com/pawland/order/respository/OrderJpaRepository.java
@@ -5,8 +5,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface OrderJpaRepository extends JpaRepository<Order,Long> {
     Page<Order> findBySellerIdOrderByCreatedDate(Long sellerId,Pageable pagable);
     Page<Order> findByBuyerIdOrderByCreatedDate(Long buyerId,Pageable pagable);
     Page<Order> findBySellerIdOrBuyerIdOrderByCreatedDate(Long sellerId, Long buyerId, Pageable pageable);
+
+    Optional<Order> findByBuyerIdAndProductId(Long buyerId, Long OrderId);
 }

--- a/src/main/java/com/pawland/order/service/OrderService.java
+++ b/src/main/java/com/pawland/order/service/OrderService.java
@@ -16,8 +16,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static com.pawland.order.exception.OrderExceptionMessage.ALREADY_EXISTS_ORDER;
 
 @Service
 @RequiredArgsConstructor
@@ -33,6 +38,11 @@ public class OrderService {
         Product product = getProductById(productId);
 
         Order order = new Order(product.getSeller(), buyer, product);
+
+        Optional<Order> foundOrder = orderJpaRepository.findByBuyerIdAndProductId(buyerId, productId);
+        if (foundOrder.isPresent()) {
+            throw new AccessDeniedException(ALREADY_EXISTS_ORDER.getMessage());
+        }
 
         orderJpaRepository.save(order);
 

--- a/src/main/java/com/pawland/order/service/OrderService.java
+++ b/src/main/java/com/pawland/order/service/OrderService.java
@@ -27,6 +27,7 @@ public class OrderService {
     private final UserRepository userRepository;
     private final ProductJpaRepository productJpaRepository;
 
+    @Transactional
     public OrderResponse createOrder(Long buyerId, Long productId) {
         User buyer = getUserById(buyerId);
         Product product = getProductById(productId);


### PR DESCRIPTION
## 🛠️주요 변경 사항
- 주문 중복 생성 방지 로직을 추가했습니다.
- 주문 중복 생성 시 상태코드 302를 응답으로 내려줍니다.

## 📣리뷰어가 꼭 알아야 하는 사항
- 현재 상태 코드만 302로 내려주는데, 필요 시 Redirect URL을 응답 값에 추가 예정입니다.


