### PR TITLE
fix: 이전 채팅내역 조회 쿼리 오류 수정

### DIFF
--- a/src/main/java/com/pawland/chat/controller/ChatController.java
+++ b/src/main/java/com/pawland/chat/controller/ChatController.java
@@ -44,8 +44,8 @@ public class ChatController {
     public ResponseEntity<List<ChatRoomInfoResponse>> getChatRoomList(@AuthenticationPrincipal UserPrincipal userPrincipal) {
         List<ChatRoomInfoResponse> chatRoomList = chatService.getChatRoomList(userPrincipal.getUserId());
         return ResponseEntity
-                .status(OK)
-                .body(chatRoomList);
+            .status(OK)
+            .body(chatRoomList);
     }
 
     @PreAuthorize("hasRole('ROLE_USER')")
@@ -58,8 +58,8 @@ public class ChatController {
                                                              @Valid @RequestBody ChatRoomCreateRequest request) {
         chatService.createChatRoom(userPrincipal.getUserId(), request);
         return ResponseEntity
-                .status(CREATED)
-                .body(new ApiMessageResponse("채팅방 생성 완료"));
+            .status(CREATED)
+            .body(new ApiMessageResponse("채팅방 생성 완료"));
     }
 
     @PreAuthorize("hasRole('ROLE_USER') && hasPermission(#roomId, 'CHATROOM', 'READ')")
@@ -67,8 +67,8 @@ public class ChatController {
     @ApiResponse(responseCode = "200", description = "채팅 내역 조회 성공")
     @ApiResponse(responseCode = "500", description = "서버 내부 오류")
     @GetMapping("/previous/{roomId}")
-    public ResponseEntity<ChatMessageHistoryResponse> getPreviousChatMessage(@PathVariable String roomId,
-                                                            @RequestParam(required = false) String messageTime) {
+    public ResponseEntity<ChatMessageHistoryResponse> getPreviousMessage(@PathVariable String roomId,
+                                                                         @RequestParam(required = false) String messageTime) {
         ChatMessageHistoryResponse chatMessageHistory = chatService.getChatMessageHistory(roomId, messageTime);
         return ResponseEntity
             .status(OK)

--- a/src/main/java/com/pawland/chat/repository/ChatMessageRepositoryImpl.java
+++ b/src/main/java/com/pawland/chat/repository/ChatMessageRepositoryImpl.java
@@ -24,7 +24,7 @@ public class ChatMessageRepositoryImpl implements ChatMessageRepositoryCustom {
             .selectFrom(chatMessage)
             .where(
                 roomIdEq(roomId),
-                messageTimeLt(messageTime)
+                messageTimeLoe(messageTime)
             )
             .orderBy(chatMessage.messageTime.desc())
             .limit(pageSize)
@@ -36,11 +36,11 @@ public class ChatMessageRepositoryImpl implements ChatMessageRepositoryCustom {
         return hasText(roomId) ? chatMessage.roomId.eq(roomIdToLong) : null;
     }
 
-    private BooleanExpression messageTimeLt(String messageTime) {
+    private BooleanExpression messageTimeLoe(String messageTime) {
         if (messageTime == null) {
             return null;
         }
         LocalDateTime cursorId = LocalDateTime.parse(messageTime);
-        return chatMessage.messageTime.lt(cursorId);
+        return chatMessage.messageTime.loe(cursorId);
     }
 }

--- a/src/test/java/com/pawland/chat/repository/ChatMessageRepositoryTest.java
+++ b/src/test/java/com/pawland/chat/repository/ChatMessageRepositoryTest.java
@@ -173,11 +173,11 @@ class ChatMessageRepositoryTest {
                 assertThat(result.size()).isEqualTo(5L);
                 assertThat(result).extracting("roomId", "message", "senderId", "messageTime")
                     .containsExactly(
+                        tuple(1L, "내용7", 1L, LocalDateTime.parse("2024-05-11T21:00:00.007")),
                         tuple(1L, "내용6", 2L, LocalDateTime.parse("2024-05-11T21:00:00.006")),
                         tuple(1L, "내용5", 1L, LocalDateTime.parse("2024-05-11T21:00:00.005")),
                         tuple(1L, "내용4", 2L, LocalDateTime.parse("2024-05-11T21:00:00.004")),
-                        tuple(1L, "내용3", 1L, LocalDateTime.parse("2024-05-11T21:00:00.003")),
-                        tuple(1L, "내용2", 2L, LocalDateTime.parse("2024-05-11T21:00:00.002"))
+                        tuple(1L, "내용3", 1L, LocalDateTime.parse("2024-05-11T21:00:00.003"))
                     );
             }
 
@@ -234,16 +234,17 @@ class ChatMessageRepositoryTest {
                 );
 
                 // then
-                assertThat(result.size()).isEqualTo(3L);
+                assertThat(result.size()).isEqualTo(4L);
                 assertThat(result).extracting("roomId", "message", "senderId", "messageTime")
                     .containsExactly(
+                        tuple(1L, "내용4", 2L, LocalDateTime.parse("2024-05-11T21:00:00.004")),
                         tuple(1L, "내용3", 1L, LocalDateTime.parse("2024-05-11T21:00:00.003")),
                         tuple(1L, "내용2", 2L, LocalDateTime.parse("2024-05-11T21:00:00.002")),
                         tuple(1L, "내용1", 1L, LocalDateTime.parse("2024-05-11T21:00:00.001"))
                     );
             }
 
-            @DisplayName("이전 채팅 데이터 수가 0이면 빈 리스트를 반환한다.")
+            @DisplayName("cursorId가 마지막 채팅일 시 마지막 메시지를 반환한다.")
             @Test
             void getChatMessageHistory4() {
                 // given
@@ -264,7 +265,11 @@ class ChatMessageRepositoryTest {
                 );
 
                 // then
-                assertThat(result.size()).isEqualTo(0L);
+                assertThat(result.size()).isEqualTo(1L);
+                assertThat(result).extracting("roomId", "message", "senderId", "messageTime")
+                    .containsExactly(
+                        tuple(1L, "내용1", 1L, LocalDateTime.parse("2024-05-11T21:00:00.001"))
+                    );
             }
         }
     }

--- a/src/test/java/com/pawland/chat/repository/ChatRoomRepositoryTest.java
+++ b/src/test/java/com/pawland/chat/repository/ChatRoomRepositoryTest.java
@@ -18,7 +18,6 @@ import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 
-import static com.pawland.product.domain.Status.SELLING;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
 

--- a/src/test/java/com/pawland/chat/service/ChatServiceTest.java
+++ b/src/test/java/com/pawland/chat/service/ChatServiceTest.java
@@ -30,7 +30,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.IntStream;
 
-import static com.pawland.product.domain.Status.SELLING;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.groups.Tuple.tuple;
@@ -520,10 +519,11 @@ class ChatServiceTest {
                 );
 
                 // then
-                assertThat(result.getNextCursor()).isEqualTo("2024-05-11T21:00:00.001");
+                assertThat(result.getNextCursor()).isEqualTo("2024-05-11T21:00:00.002");
                 assertThat(result.getMessageList().size()).isEqualTo(10L);
                 assertThat(result.getMessageList()).extracting("message", "sender", "messageTime")
                     .containsExactly(
+                        tuple("내용12", "2", "2024-05-11T21:00:00.012"),
                         tuple("내용11", "1", "2024-05-11T21:00:00.011"),
                         tuple("내용10", "2", "2024-05-11T21:00:00.010"),
                         tuple("내용9", "1", "2024-05-11T21:00:00.009"),
@@ -532,8 +532,7 @@ class ChatServiceTest {
                         tuple("내용6", "2", "2024-05-11T21:00:00.006"),
                         tuple("내용5", "1", "2024-05-11T21:00:00.005"),
                         tuple("내용4", "2", "2024-05-11T21:00:00.004"),
-                        tuple("내용3", "1", "2024-05-11T21:00:00.003"),
-                        tuple("내용2", "2", "2024-05-11T21:00:00.002")
+                        tuple("내용3", "1", "2024-05-11T21:00:00.003")
                     );
             }
 
@@ -544,7 +543,7 @@ class ChatServiceTest {
                 Long roomId = 1L;
                 Long userId1 = 1L;
                 Long userId2 = 2L;
-                List<ChatMessage> chatMessages = IntStream.rangeClosed(1, 11)
+                List<ChatMessage> chatMessages = IntStream.rangeClosed(1, 10)
                     .mapToObj(i -> i % 2 == 1
                         ? createChatMessage(roomId, "내용" + i, userId1, "2024-05-11T21:00:00.0" + String.format("%02d", i))
                         : createChatMessage(roomId, "내용" + i, userId2, "2024-05-11T21:00:00.0" + String.format("%02d", i))
@@ -554,7 +553,7 @@ class ChatServiceTest {
 
                 // when
                 ChatMessageHistoryResponse result = chatService.getChatMessageHistory(
-                    roomId.toString(), "2024-05-11T21:00:00.011"
+                    roomId.toString(), "2024-05-11T21:00:00.010"
                 );
 
                 // then
@@ -597,16 +596,17 @@ class ChatServiceTest {
 
                 // then
                 assertThat(result.getNextCursor()).isNull();
-                assertThat(result.getMessageList().size()).isEqualTo(3L);
+                assertThat(result.getMessageList().size()).isEqualTo(4L);
                 assertThat(result.getMessageList()).extracting("message", "sender", "messageTime")
                     .containsExactly(
+                        tuple("내용4", "2", "2024-05-11T21:00:00.004"),
                         tuple("내용3", "1", "2024-05-11T21:00:00.003"),
                         tuple("내용2", "2", "2024-05-11T21:00:00.002"),
                         tuple("내용1", "1", "2024-05-11T21:00:00.001")
                     );
             }
 
-            @DisplayName("이전 채팅 데이터 수가 0이면 빈 리스트를 반환하고, nextCursor 값은 null이다.")
+            @DisplayName("cursorId가 마지막 채팅이면 마지막 메시지를 반환하고, nextCursor 값은 null이다.")
             @Test
             void getChatMessageHistory4() {
                 // given
@@ -628,7 +628,11 @@ class ChatServiceTest {
 
                 // then
                 assertThat(result.getNextCursor()).isNull();
-                assertThat(result.getMessageList().size()).isEqualTo(0L);
+                assertThat(result.getMessageList().size()).isEqualTo(1L);
+                assertThat(result.getMessageList()).extracting("message", "sender", "messageTime")
+                    .containsExactly(
+                        tuple("내용1", "1", "2024-05-11T21:00:00.001")
+                    );
             }
         }
     }


### PR DESCRIPTION
## 🛠️주요 변경 사항
- Loe로 했어야했는데 Lt로 해서 cursorId가 가리키는 메시지를 조회하지 않는 버그 수정

## 📣리뷰어가 꼭 알아야 하는 사항
- 깃헙액션 CI를 확인하고 머지했어야 했는데 급하게 했더니 컨트롤러 테스트 수정을 누락했습니다.
- 수정 후 develop 브랜치에 강제 푸시해둬서 오류는 없습니다.

## ❗관련이슈
- closed: #41 